### PR TITLE
Add Java Files from java_path-traversal-annotated - Batch 02

### DIFF
--- a/row_002_Cryptonite.java
+++ b/row_002_Cryptonite.java
@@ -1,0 +1,1558 @@
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+// Copyright (c) 2012, Christoph Schmidt-Hieber
+
+package csh.cryptonite;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
+
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.ActivityManager.RunningServiceInfo;
+
+import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+
+import android.graphics.drawable.Drawable;
+
+import android.net.Uri;
+
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.Settings;
+
+import android.support.v4.view.ViewPager;
+
+import android.text.SpannableString;
+import android.text.util.Linkify;
+import android.text.method.ScrollingMovementMethod;
+
+import android.util.Base64;
+import android.util.Log;
+
+import android.widget.TabHost;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.actionbarsherlock.app.SherlockDialogFragment;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
+import com.actionbarsherlock.view.Menu;
+import com.actionbarsherlock.view.MenuInflater;
+import com.actionbarsherlock.view.MenuItem;
+import com.dropbox.client2.DropboxAPI;
+import com.dropbox.client2.android.AndroidAuthSession;
+import com.dropbox.client2.session.AppKeyPair;
+import com.dropbox.client2.session.Session.AccessType;
+
+import csh.cryptonite.database.Volume;
+import csh.cryptonite.database.VolumesDataSource;
+import csh.cryptonite.storage.DropboxInterface;
+import csh.cryptonite.storage.DropboxFragment;
+import csh.cryptonite.storage.LocalFragment;
+import csh.cryptonite.storage.MountManager;
+import csh.cryptonite.storage.Storage;
+import csh.cryptonite.storage.StorageManager;
+import csh.cryptonite.storage.VirtualFile;
+import csh.cryptonite.storage.VirtualFileSystem;
+
+public class Cryptonite extends SherlockFragmentActivity
+{
+
+    private static final int REQUEST_PREFS=0, REQUEST_CODE_PICK_FILE_OR_DIRECTORY=1;
+    public static final int MOUNT_MODE=0, SELECTLOCALENCFS_MODE=1, SELECTDBENCFS_MODE=2,
+        VIEWMOUNT_MODE=3, SELECTLOCALEXPORT_MODE=4, LOCALEXPORT_MODE=5, DROPBOX_AUTH_MODE=6,
+        SELECTDBEXPORT_MODE=7, DBEXPORT_MODE=8, SELECTLOCALUPLOAD_MODE=9, SELECTDBUPLOAD_MODE=10;
+    public static final int RESULT_RETRY = 1;
+    public static final int RESULT_ERROR = 2;
+    public static final int RESULT_NOCONFIG = 3;
+    
+    private static final int DIRPICK_MODE=0;
+    public static final int FILEPICK_MODE=1;
+    protected static final int MSG_SHOW_TOAST = 0;
+    private static final int DIALOG_JNI_FAIL=3;
+    private static final int MAX_JNI_SIZE = 512;
+    public static final int TERM_UNAVAILABLE=0, TERM_OUTDATED=1, TERM_AVAILABLE=2;
+    public static final String MNTPNT = "/csh.cryptonite/mnt";
+    public static final String TAG = "cryptonite";
+    public static final String DBTAB_TAG = "tab_db", LOCALTAB_TAG="tab_local", EXPERTTAB_TAG="tab_expert";
+
+    private String encfsVersion;
+    private String opensslVersion;
+    private String bcWallet;
+    public String mountInfo;
+    public String textOut;
+    
+    private static boolean hasJni = false;
+    
+    public String currentDialogStartPath = "/";
+    public String currentDialogLabel = "";
+    public String currentDialogButtonLabel = "OK";
+    public String currentDialogRoot = "/";
+    public String currentDialogRootName = currentDialogRoot;
+    public String currentConfigFile = "";
+    private String currentReturnPath = "/";
+    private String currentOpenPath = "/";
+    private String currentUploadTargetPath = "/";
+    private String encfsBrowseRoot = "/";
+    private String[] currentReturnPathList = {};
+    public int currentDialogMode = SelectionMode.MODE_OPEN_ENCFS;
+
+    public int opMode = -1;
+    public int prevMode = -1;
+    private boolean alert = false;
+    private String alertMsg = "";
+ 
+    public boolean mLoggedIn = false;
+    public boolean hasFuse = false;
+    public boolean triedLogin = false;
+    private boolean mInstrumentation = false;
+    private boolean mUseAppFolder;
+    private boolean disclaimerShown = false;
+
+    private TabHost mTabHost;
+    private ViewPager  mViewPager;
+    private TabsAdapter mTabsAdapter;
+
+    private DropboxFragment dbFragment;
+    private LocalFragment localFragment;
+
+    private VolumesDataSource mDataSource;
+    private boolean updateDecryptDelayed;
+
+    // If you'd like to change the access type to the full Dropbox instead of
+    // an app folder, change this value.
+    final static private AccessType ACCESS_TYPE = AccessType.DROPBOX;
+
+    final static public String ACCOUNT_PREFS_NAME = "csh.cryptonite_preferences";
+    final static public String ACCOUNT_DB_PREFS_NAME = "csh.cryptonite_db_preferences";
+    final static private String ACCESS_TOKEN_NAME = "ACCESS_TOKEN";
+    
+    /** Called when the activity is first created. */
+    @Override public void onCreate(Bundle savedInstanceState) {
+
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.main);
+
+        getResources();
+
+        if (!hasJni) {
+            jniFail();
+            return;
+        }
+
+        mDataSource = new VolumesDataSource(this);
+        mDataSource.open();
+
+        encfsVersion = "EncFS " + jniEncFSVersion();
+        opensslVersion = jniOpenSSLVersion();
+        bcWallet = jniBcWallet();
+        textOut = encfsVersion + "\n" + opensslVersion + "\nBC donations: " + bcWallet;
+        Log.v(TAG, encfsVersion + " " + opensslVersion);
+
+        updateDecryptDelayed = false;
+        
+        SharedPreferences prefs = getBaseContext().getSharedPreferences(ACCOUNT_PREFS_NAME, 0);
+        setupReadDirs(prefs.getBoolean("cb_extcache", false));
+        StorageManager.INSTANCE.initLocalStorage(this);
+
+        if (!externalStorageIsWritable() || !ShellUtils.supportsFuse()) {
+            mountInfo = getString(R.string.mount_info_unsupported);
+        } else {
+            mountInfo = getString(R.string.mount_info);
+            DirectorySettings.INSTANCE.mntDir = prefs.getString("txt_mntpoint", Cryptonite.defaultMntDir());
+            File mntDirF = new File(DirectorySettings.INSTANCE.mntDir);
+            if (!mntDirF.exists()) {
+                mntDirF.mkdirs();
+            }
+        }
+
+        DirectorySettings.INSTANCE.binDirPath = getFilesDir().getParentFile().getPath();
+        DirectorySettings.INSTANCE.encFSBin = DirectorySettings.INSTANCE.binDirPath + "/encfs";
+
+        hasFuse = ShellUtils.supportsFuse();
+        
+        /* Running from Instrumentation? */
+        if (getIntent() != null) {
+            mInstrumentation = getIntent().getBooleanExtra("csh.cryptonite.instrumentation", false);
+        } else {
+            mInstrumentation = false;
+        }
+        
+        if (needsEncFSBinary()) {
+            ProgressDialogFragment.showDialog(this, R.string.copying_bins, "copyingBins");
+            new Thread(new Runnable(){
+                public void run(){
+                    cpBin("encfs");
+                    cpBin("truecrypt");
+                    runOnUiThread(new Runnable(){
+                        public void run() {
+                            ProgressDialogFragment.dismissDialog(Cryptonite.this, "copyingBins");
+                            setEncFSBinaryVersion();
+                        }
+                    });
+                }
+            }).start();
+        }
+        
+        mTabHost = (TabHost)findViewById(android.R.id.tabhost);
+        mTabHost.setup();
+
+        mViewPager = (ViewPager)findViewById(R.id.pager);
+        mTabsAdapter = new TabsAdapter(this, mTabHost, mViewPager);
+        
+        mTabsAdapter.addTab(mTabHost.newTabSpec(DBTAB_TAG)
+                .setIndicator(getString(R.string.dropbox_tabtitle)),
+                DropboxFragment.class, null);
+        mTabsAdapter.addTab(mTabHost.newTabSpec(LOCALTAB_TAG)
+                .setIndicator(getString(R.string.local_tabtitle)),
+                LocalFragment.class, null);
+        mTabsAdapter.addTab(mTabHost.newTabSpec(EXPERTTAB_TAG)
+                .setIndicator(getString(R.string.expert_tabtitle)),
+                ExpertFragment.class, null);
+
+        if (savedInstanceState != null) {
+            mTabHost.setCurrentTabByTag(savedInstanceState.getString("tab"));
+            opMode = savedInstanceState.getInt("opMode");
+            if (savedInstanceState.getString("currentReturnPath") != null) {
+                currentReturnPath = savedInstanceState.getString("currentReturnPath");
+            }
+            if (savedInstanceState.getString("currentDialogStartPath") != null) {
+                currentDialogStartPath = savedInstanceState.getString("currentDialogStartPath");
+            }
+            if (savedInstanceState.getString("currentDialogRoot") != null) {
+                currentDialogRoot = savedInstanceState.getString("currentDialogRoot");
+            }
+            if (savedInstanceState.getString("currentDialogLabel") != null) {
+                currentDialogLabel = savedInstanceState.getString("currentDialogLabel");
+            }
+            if (savedInstanceState.getString("currentDialogButtonLabel") != null) {
+                currentDialogButtonLabel = savedInstanceState.getString("currentDialogButtonLabel");
+            }
+            if (savedInstanceState.getString("currentDialogRootName") != null) {
+                currentDialogRootName = savedInstanceState.getString("currentDialogRootName");
+            }
+            if (savedInstanceState.getString("currentOpenPath") != null) {
+                currentOpenPath = savedInstanceState.getString("currentOpenPath");
+            }
+            if (savedInstanceState.getString("currentUploadTargetPath") != null) {
+                currentUploadTargetPath = savedInstanceState.getString("currentUploadTargetPath");
+            }
+            if (savedInstanceState.getString("encfsBrowseRoot") != null) {
+                encfsBrowseRoot = savedInstanceState.getString("encfsBrowseRoot");
+            }
+            if (savedInstanceState.getString("currentConfigFile") != null) {
+                currentConfigFile = savedInstanceState.getString("currentConfigFile");
+            }
+            if (savedInstanceState.getStringArray("currentReturnPathList") != null) {
+                currentReturnPathList = savedInstanceState.getStringArray("currentReturnPathList");
+            }
+            if (savedInstanceState.getInt("currentDialogMode") != 0) {
+                currentDialogMode = savedInstanceState.getInt("currentDialogMode");
+            }
+            disclaimerShown = savedInstanceState.getBoolean("disclaimerShown");
+            if (currentReturnPath != null && currentDialogStartPath != null) {
+                DirectorySettings.INSTANCE.currentBrowsePath = currentReturnPath;
+                DirectorySettings.INSTANCE.currentBrowseStartPath = currentDialogStartPath;
+            }
+            int storageType = savedInstanceState.getInt("storageType");
+            if (storageType != Storage.STOR_UNDEFINED) {
+                StorageManager.INSTANCE.initEncFSStorage(this, storageType);
+                if (savedInstanceState.getString("encFSPath") != null) {
+                    StorageManager.INSTANCE.setEncFSPath(savedInstanceState.getString("encFSPath"));
+                }
+            }
+            
+        }
+        
+        String oAuth2AccessToken = getOAuth2AccessToken();
+        if (oAuth2AccessToken != null) {
+            if (prefs.getBoolean("dbDecided", false)) {            
+                setSession(prefs.getBoolean("cb_appfolder", false), false);
+                updateDecryptButtons();
+            }
+        }
+
+        if (DropboxInterface.INSTANCE.getDBApi() != null && 
+                DropboxInterface.INSTANCE.getDBApi().getSession() != null)
+        {
+            mLoggedIn = DropboxInterface.INSTANCE.getDBApi().getSession().isLinked();
+        } else {
+            mLoggedIn = false;
+        }
+
+        if (!mInstrumentation && !prefs.getBoolean("cb_norris", false) && !disclaimerShown) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(Cryptonite.this);
+            builder.setIcon(R.drawable.ic_launcher_cryptonite)
+                .setTitle(R.string.disclaimer)
+                .setMessage(R.string.no_warranty)
+                .setPositiveButton(R.string.understand,
+                                   new DialogInterface.OnClickListener() {
+                                       public void onClick(DialogInterface dialog,
+                                                           int which) {
+                                           disclaimerShown = true;
+                                       }
+                                   });
+            AlertDialog dialog = builder.create();
+            dialog.show();
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (mTabHost != null) {
+            outState.putString("tab", mTabHost.getCurrentTabTag());
+        }
+        outState.putInt("opMode", opMode);
+        outState.putString("currentReturnPath", currentReturnPath);
+        outState.putString("currentDialogStartPath", currentDialogStartPath);
+        outState.putString("currentDialogRoot", currentDialogRoot);
+        outState.putString("currentDialogLabel", currentDialogLabel);
+        outState.putString("currentDialogButtonLabel", currentDialogButtonLabel);
+        outState.putString("currentDialogRootName", currentDialogRootName);
+        outState.putString("currentOpenPath", currentOpenPath);
+        outState.putString("currentUploadTargetPath", currentUploadTargetPath);
+        outState.putString("encfsBrowseRoot", encfsBrowseRoot);
+        outState.putString("currentConfigFile", currentConfigFile);
+        outState.putStringArray("currentReturnPathList", currentReturnPathList);
+        outState.putInt("currentDialogMode", currentDialogMode);
+        outState.putBoolean("disclaimerShown", disclaimerShown);
+        if (StorageManager.INSTANCE.getEncFSStorage() != null) {
+            outState.putInt("storageType", StorageManager.INSTANCE.getEncFSStorageType());
+            outState.putString("encFSPath", StorageManager.INSTANCE.getEncFSPath());
+        } else {
+            outState.putInt("storageType", Storage.STOR_UNDEFINED);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        if (mDataSource != null) {
+            mDataSource.open();
+        }
+        super.onResume();
+        if (!hasJni) {
+            return;
+        }
+        if (updateDecryptDelayed) {
+            updateDecryptDelayed = false;
+            updateDecryptButtons();
+        }
+
+        finishAuthentication();   
+    }
+
+    @Override
+    protected void onPause() {
+        if (mDataSource != null) {
+            mDataSource.close();
+        }
+        super.onPause();
+    }
+
+    public static boolean isValidMntDir(Context context, File newMntDir) {
+        return isValidMntDir(context, newMntDir, true);
+    }
+    
+    public static boolean isValidMntDir(Context context, File newMntDir, boolean showToast) {
+        if (!newMntDir.exists()) {
+            if (showToast) {
+                Toast.makeText(context, R.string.txt_mntpoint_nexists, Toast.LENGTH_LONG).show();
+            }
+            return false;
+        }
+        if (!newMntDir.isDirectory()) {
+            if (showToast) {
+                Toast.makeText(context, R.string.txt_mntpoint_nisdir, Toast.LENGTH_LONG).show();
+            }
+            return false;
+        }
+        if (!newMntDir.canWrite()) {
+            if (showToast) {
+                Toast.makeText(context, R.string.txt_mntpoint_ncanwrite, Toast.LENGTH_LONG).show();
+            }
+            return false;
+        }
+        if (newMntDir.list().length != 0) {
+            if (showToast) {
+                Toast.makeText(context, R.string.txt_mntpoint_nempty, Toast.LENGTH_LONG).show();
+            }
+            return false;
+        }
+        return true;
+    }
+
+    public static String defaultMntDir() {
+        return DirectorySettings.getGlobalExternalStorageDirectory().getPath() + MNTPNT;
+    }
+
+    /** Called upon exit from other activities */
+    public synchronized void onActivityResult(final int requestCode,
+            int resultCode, final Intent data) 
+    {
+
+        switch (requestCode) {
+        case SelectionMode.MODE_OPEN_ENCFS:
+        case SelectionMode.MODE_OPEN_ENCFS_DB:
+        case SelectionMode.MODE_OPEN_DEFAULT:
+        case SelectionMode.MODE_OPEN_DEFAULT_DB:
+        case SelectionMode.MODE_OPEN_UPLOAD_SOURCE:
+        case SelectionMode.MODE_OPEN_CREATE:
+            /* file dialog */
+            if (resultCode == Activity.RESULT_OK && data != null) {
+                currentReturnPath = data.getStringExtra(FileDialog.RESULT_EXPORT_PATHS);
+                if (currentReturnPath != null ) {
+                    switch (opMode) {
+                    case MOUNT_MODE:
+                        opMode = prevMode;
+                        if (localFragment != null) {
+                            localFragment.updateMountButtons();
+                        }
+                        break;
+                    case SELECTLOCALENCFS_MODE:
+                    case SELECTDBENCFS_MODE:
+                        /* TODO: This is now handle in FileDialog.java
+                        if (requestCode != SelectionMode.MODE_OPEN_DEFAULT_DB) {
+                            StorageManager.INSTANCE.setEncFSPath(currentReturnPath
+                                    .substring(currentDialogStartPath.length()));
+                        } else {
+                            StorageManager.INSTANCE.setEncFSPath(currentReturnPath
+                                    .substring(currentDialogRoot.length()));
+                        }*/
+                        updateDecryptDelayed = true;
+                        break;
+                    case LOCALEXPORT_MODE:
+                    case DBEXPORT_MODE:
+                    case SELECTDBUPLOAD_MODE:
+                    case SELECTLOCALUPLOAD_MODE:
+                        break;
+                    }
+                }
+            } else if (resultCode == Activity.RESULT_CANCELED) {
+            } else if (resultCode == RESULT_RETRY) {
+                launchBuiltinFileBrowser();
+            }
+            break;
+        case SelectionMode.MODE_OPEN_MULTISELECT:
+        case SelectionMode.MODE_OPEN_MULTISELECT_DB:
+            if (resultCode == Activity.RESULT_OK && data != null) {
+                currentReturnPathList = data
+                        .getStringArrayExtra(FileDialog.RESULT_EXPORT_PATHS);
+                if (currentReturnPathList != null
+                        && currentReturnPathList.length > 0)
+                {
+                    /* Select destination directory for exported files */
+                    currentDialogLabel = Cryptonite.this
+                            .getString(R.string.select_exp);
+                    currentDialogButtonLabel = Cryptonite.this
+                            .getString(R.string.select_exp_short);
+                    currentDialogMode = SelectionMode.MODE_OPEN_EXPORT_TARGET;
+                    if (externalStorageIsWritable()) {
+                        currentDialogStartPath = getDownloadDir().getPath();
+                        File downloadDir = new File(currentDialogStartPath);
+                        if (!downloadDir.exists()) {
+                            downloadDir.mkdir();
+                        }
+                        if (!downloadDir.exists()) {
+                            currentDialogStartPath = "/";
+                        }
+                    } else {
+                        currentDialogStartPath = "/";
+                    }
+                    currentDialogRoot = "/";
+                    currentDialogRootName = currentDialogRoot;
+                    if (StorageManager.INSTANCE.getEncFSStorage() != null) {
+                        opMode = StorageManager.INSTANCE.getEncFSStorage().exportMode;
+                    } else {
+                        return;
+                    }
+                    currentConfigFile = "";
+                    launchBuiltinFileBrowser();
+                } else {
+                    currentOpenPath = data
+                            .getStringExtra(FileDialog.RESULT_OPEN_PATH);
+                    if (currentOpenPath != null && currentOpenPath.length() > 0) {
+                        /* */
+                    } else {
+                        currentUploadTargetPath = data
+                                .getStringExtra(FileDialog.RESULT_UPLOAD_PATH);
+                        if (currentUploadTargetPath != null
+                                && currentUploadTargetPath.length() > 0)
+                        {
+                            /* select file to upload */
+                            currentDialogLabel = Cryptonite.this
+                                    .getString(R.string.select_upload);
+                            currentDialogButtonLabel = Cryptonite.this
+                                    .getString(R.string.select_upload_short);
+                            currentDialogMode = SelectionMode.MODE_OPEN_UPLOAD_SOURCE;
+                            if (externalStorageIsWritable()) {
+                                currentDialogStartPath = DirectorySettings
+                                        .getGlobalExternalStorageDirectory()
+                                        .getPath();
+                            } else {
+                                currentDialogStartPath = "/";
+                            }
+                            currentDialogRoot = "/";
+                            currentDialogRootName = currentDialogRoot;
+                            if (StorageManager.INSTANCE.getEncFSStorage() != null) {
+                                opMode = StorageManager.INSTANCE
+                                        .getEncFSStorage().uploadMode;
+                            } else {
+                                return;
+                            }
+                            currentConfigFile = "";
+                            launchBuiltinFileBrowser();
+                        }
+                    }
+                }
+            } else if (resultCode == Activity.RESULT_CANCELED) {
+
+            } else if (resultCode == RESULT_ERROR) {
+                Toast.makeText(this, R.string.decode_failure, Toast.LENGTH_LONG).show();
+                jniResetVolume();
+                StorageManager.INSTANCE.resetEncFSStorage();
+                VirtualFileSystem.INSTANCE.clear();
+            }
+            break;
+        case REQUEST_PREFS:
+            SharedPreferences prefs = getBaseContext().getSharedPreferences(ACCOUNT_PREFS_NAME, 0);
+            Editor prefEdit = prefs.edit();
+            
+            setupReadDirs(prefs.getBoolean("cb_extcache", false));
+            
+            DirectorySettings.INSTANCE.mntDir = prefs.getString("txt_mntpoint", defaultMntDir());
+
+            /* If app folder settings have changed, we'll have to log out the user
+             * from his Dropbox and restart the authentication from scratch during
+             * the next login:
+             */
+            if (prefs.getBoolean("cb_appfolder", false) != mUseAppFolder) {
+                prefEdit.putBoolean("dbDecided", true);
+                prefEdit.commit();
+                /* enforce re-authentication */
+                DropboxInterface.INSTANCE.setDBApi(null);
+                if (mLoggedIn) {
+                    Toast.makeText(Cryptonite.this,
+                            R.string.dropbox_forced_logout,
+                            Toast.LENGTH_LONG).show();
+                    logOut();
+                }
+            }
+            break;
+        case REQUEST_CODE_PICK_FILE_OR_DIRECTORY:
+            /* from external OI file browser */
+            if (resultCode == RESULT_OK && data != null) {
+                // obtain the filename
+                Uri fileUri = data.getData();
+                if (fileUri != null) {
+                    currentReturnPath = fileUri.getPath();
+                }
+            }
+            break;
+        case CreateEncFS.CREATE_DB:
+        case CreateEncFS.CREATE_LOCAL:
+            break;
+        case TextPreview.REQUEST_PREVIEW:
+            break;
+        default:
+            Log.e(TAG, "Unknown request code");
+        }
+    }
+
+    public void finishAuthentication() {
+        if (DropboxInterface.INSTANCE.getDBApi() != null && 
+                DropboxInterface.INSTANCE.getDBApi().getSession() != null)
+        {
+            if (triedLogin) {
+                AndroidAuthSession session = DropboxInterface.INSTANCE.getDBApi().getSession();
+                // The next part must be inserted in the onResume() method of the
+                // activity from which session.startAuthentication() was called, so
+                // that Dropbox authentication completes properly.
+                // Make sure we're returning from an authentication attempt at all.
+                triedLogin = false;
+                if (session.authenticationSuccessful()) {
+                    try {
+                        // Mandatory call to complete the auth
+                        session.finishAuthentication();
+        
+                        // Store it locally in our app for later use
+                        storeKeys(session.getOAuth2AccessToken());
+                        
+                        DropboxInterface.INSTANCE.clearDBHashMap();
+                        
+                        setLoggedIn(true);
+                    } catch (IllegalStateException e) {
+                        Toast.makeText(Cryptonite.this, 
+                                getString(R.string.dropbox_auth_fail) + ": " + e.getLocalizedMessage(), 
+                                Toast.LENGTH_LONG).show();
+                    }
+                } else {
+                    if (!session.isLinked()) {
+                        logOut();
+                    }
+                }
+            } else {
+                mLoggedIn = DropboxInterface.INSTANCE.getDBApi().getSession().isLinked();
+            }
+        } else {
+            setLoggedIn(false);
+        }
+    }
+    
+    public void showAlert(int alert_id, int msg_id) {
+        showAlert(getString(alert_id), getString(msg_id));
+    }
+    
+    private void showAlert(int alert_id, String msg) {
+        showAlert(getString(alert_id), msg);
+    }
+    
+    private void showAlert(String alert, String msg) {
+        showAlert(alert, msg, "OK");
+    }
+    
+    private void showAlert(String alert, String msg, String btnLabel) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(Cryptonite.this);
+        builder.setIcon(R.drawable.ic_launcher_cryptonite)
+            .setTitle(alert)
+            .setMessage(msg)
+            .setPositiveButton(btnLabel,
+                               new DialogInterface.OnClickListener() {
+                                   public void onClick(DialogInterface dialog,
+                                                       int which) {
+                                       
+                                   }
+                               });
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+    /** Deletes all files and subdirectories under dir.
+     * Returns true if all deletions were successful.
+     * If a deletion fails, the method stops attempting to delete and returns false.
+     */
+    public static boolean deleteDir(File dir) {
+        if (dir == null) {
+            return false;
+        }
+        if (dir.isDirectory()) {
+            String[] children = dir.list();
+            for (int i=0; i<children.length; i++) {
+                boolean success = deleteDir(new File(dir, children[i]));
+                if (!success) {
+                    return false;
+                }
+            }
+        }
+
+        // The directory is now empty so delete it
+        return dir.delete();
+    }
+
+   public void updateDecryptButtons() {
+       if (dbFragment != null) {
+           dbFragment.updateDecryptButtons();
+       }
+       if (localFragment != null) {
+           localFragment.updateDecryptButtons();
+       }
+   }
+
+   /** Browse an EncFS volume using a virtual file system.
+    * File names are queried on demand when a directory is opened.
+    * @param browsePath EncFS path 
+    * @param browseStartPath Root path
+    */
+   public void browseEncFS(final String browsePath, final String browseStartPath) {
+        final VirtualFile browseDirF = new VirtualFile(VirtualFile.VIRTUAL_TAG
+                + "/" + StorageManager.INSTANCE.getEncFSStorage().browsePnt);
+        browseDirF.mkdirs();
+
+        new Thread(new Runnable() {
+            public void run() {
+                Log.i(TAG, "Dialog root is " + browsePath);
+                currentDialogStartPath = browseDirF.getPath();
+                currentDialogLabel = getString(R.string.select_file_export);
+                currentDialogButtonLabel = getString(R.string.export);
+                currentDialogRoot = currentDialogStartPath;
+                encfsBrowseRoot = currentDialogRoot;
+                currentConfigFile = "";
+                currentDialogRootName = getString(R.string.encfs_root);
+                currentDialogMode = StorageManager.INSTANCE.getEncFSStorage().fdSelectionMode;
+                runOnUiThread(new Runnable() {
+                    public void run() {
+                        opMode = StorageManager.INSTANCE.getEncFSStorage().selectExportMode;
+                        launchBuiltinFileBrowser();
+                    }
+                });
+            }
+        }).start();
+    }
+    
+    public File getPrivateDir(String label) {
+        return getPrivateDir(label, Context.MODE_PRIVATE);
+    }
+    
+    public File getPrivateDir(String label, int mode) {
+        /* Tear down and recreate the browse directory to make
+         * sure we have appropriate permissions */
+        File browseDirF = getBaseContext().getDir(label, mode);
+        if (browseDirF.exists()) {
+            if (!deleteDir(browseDirF)) {
+                showAlert(R.string.error, R.string.target_dir_cleanup_failure);
+                return null;
+            }
+        }
+        browseDirF = getBaseContext().getDir(label, mode);
+        return browseDirF;
+    }
+
+    /** Creates an options menu */
+    @Override public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getSherlock().getMenuInflater();
+        inflater.inflate(R.menu.menu, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    /** Opens the options menu */
+    @Override public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle item selection
+        switch (item.getItemId()) {
+         case R.id.preferences:
+             SharedPreferences prefs = getBaseContext().getSharedPreferences(ACCOUNT_PREFS_NAME, 0);
+             /* Store current app folder choice */
+             mUseAppFolder = prefs.getBoolean("cb_appfolder", false);
+             Intent settingsActivity = new Intent(getBaseContext(),
+                                                  Preferences.class);
+             startActivityForResult(settingsActivity, REQUEST_PREFS);
+             return true;
+         case R.id.about:
+             AlertDialog builder;
+             try {
+                 builder = AboutDialogBuilder.create(this);
+                 builder.show();
+                 return true;
+             } catch (PackageManager.NameNotFoundException e) {
+                 return false;
+             }
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private static class AboutDialogBuilder {
+        public static AlertDialog create(Context context) throws PackageManager.NameNotFoundException {
+            PackageInfo pInfo = context.getPackageManager().
+                getPackageInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            Drawable pIcon = context.getPackageManager().
+                getApplicationIcon(context.getPackageName());
+            String aboutTitle = String.format("%s %s", context.getString(R.string.app_name), pInfo.versionName);
+            String aboutText = context.getString(R.string.about);
+
+            final TextView message = new TextView(context);
+            final SpannableString s = new SpannableString(aboutText);
+
+            message.setPadding(5, 5, 5, 5);
+            message.setMovementMethod(new ScrollingMovementMethod());
+            message.setText(s);
+            Linkify.addLinks(message, Linkify.ALL);
+
+            return new AlertDialog.Builder(context).setTitle(aboutTitle).
+                setIcon(pIcon).
+                setCancelable(true).
+                setPositiveButton(context.getString(android.R.string.ok), null).
+                setView(message).create();
+        }
+    }
+
+    public static boolean externalStorageIsWritable() {
+        /* Check sd card state */
+        String state = Environment.getExternalStorageState();
+
+        boolean extStorAvailable = false;
+        boolean extStorWriteable = false;
+
+        if (Environment.MEDIA_MOUNTED.equals(state)) {
+            // We can read and write the media
+            extStorAvailable = extStorWriteable = true;
+        } else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
+            // We can only read the media
+            extStorAvailable = true;
+            extStorWriteable = false;
+        } else {
+            // Something else is wrong. It may be one of many other states, but all we need
+            //  to know is we can neither read nor write
+            extStorAvailable = extStorWriteable = false;
+        }
+
+        return extStorAvailable && extStorWriteable;
+    }
+
+    public void launchFileBrowser(int mode) {
+        SharedPreferences prefs = getBaseContext().getSharedPreferences(ACCOUNT_PREFS_NAME, 0);
+        boolean useBuiltin = prefs.getBoolean("cb_builtin", false);
+        if (!useBuiltin) {
+            // Note the different intent: PICK_DIRECTORY
+            String oiIntent = "org.openintents.action.PICK_FILE";
+            if (mode == DIRPICK_MODE) {
+                oiIntent = "org.openintents.action.PICK_DIRECTORY";
+            }
+            Intent intent = new Intent(oiIntent);
+
+            // Construct URI from file name.
+            File file = new File(currentDialogStartPath);
+            intent.setData(Uri.fromFile(file));
+
+            intent.putExtra("org.openintents.extra.TITLE", currentDialogLabel);
+            intent.putExtra("org.openintents.extra.BUTTON_TEXT", currentDialogButtonLabel);
+
+            try {
+                startActivityForResult(intent, REQUEST_CODE_PICK_FILE_OR_DIRECTORY);
+            } catch (ActivityNotFoundException e) {
+                OIUnavailableDialogFragment newFragment = OIUnavailableDialogFragment.newInstance();
+                newFragment.show(getSupportFragmentManager(), "dialog");
+            }
+        } else {
+            launchBuiltinFileBrowser();
+        }
+
+    }
+    
+    public void launchBuiltinFileBrowser() {
+        Intent intent = new Intent(getBaseContext(), FileDialog.class);
+        intent.putExtra(FileDialog.CURRENT_ROOT, currentDialogRoot);
+        intent.putExtra(FileDialog.CURRENT_ROOT_NAME, currentDialogRootName);
+        intent.putExtra(FileDialog.BUTTON_LABEL, currentDialogButtonLabel);
+        intent.putExtra(FileDialog.START_PATH, currentDialogStartPath);
+        intent.putExtra(FileDialog.CURRENT_UPLOAD_TARGET_PATH, currentUploadTargetPath);
+        intent.putExtra(FileDialog.CURRENT_EXPORT_PATH_LIST, currentReturnPathList);
+        intent.putExtra(FileDialog.ENCFS_BROWSE_ROOT, encfsBrowseRoot);
+        intent.putExtra(FileDialog.CURRENT_CONFIG_PATH, currentConfigFile);
+        intent.putExtra(FileDialog.LABEL, currentDialogLabel);
+        intent.putExtra(FileDialog.SELECTION_MODE, currentDialogMode);
+        startActivityForResult(intent, currentDialogMode);
+    }
+    
+    public void createEncFS(final boolean isDB) {
+        SharedPreferences prefs = getBaseContext().getSharedPreferences(Cryptonite.ACCOUNT_PREFS_NAME, 0);
+        if (!prefs.getBoolean("cb_norris", false)) {
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(Cryptonite.this);
+            builder.setIcon(R.drawable.ic_launcher_cryptonite)
+            .setTitle(R.string.warning)
+            .setMessage(R.string.create_warning)
+            .setPositiveButton(R.string.create_short,
+                    new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog,
+                        int which) {
+                    Intent intent = new Intent(getBaseContext(), CreateEncFS.class);
+                    int createMode = CreateEncFS.CREATE_LOCAL;
+                    if (isDB) {
+                        createMode = CreateEncFS.CREATE_DB;
+                    }
+                    intent.putExtra(CreateEncFS.START_MODE, createMode);
+                    startActivityForResult(intent, createMode);
+                }
+            })
+            .setNegativeButton(R.string.cancel,
+                    new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog,
+                        int which) {
+                }
+            });  
+            AlertDialog dialog = builder.create();
+            dialog.show();
+        } else {
+            Intent intent = new Intent(getBaseContext(), CreateEncFS.class);
+            int createMode = CreateEncFS.CREATE_LOCAL;
+            if (isDB) {
+                createMode = CreateEncFS.CREATE_DB;
+            }
+            intent.putExtra(CreateEncFS.START_MODE, createMode);
+            startActivityForResult(intent, createMode);
+        }
+        
+        
+    }
+    
+    public void logOut() {
+        // Remove credentials from the session
+        if (DropboxInterface.INSTANCE.getDBApi() != null) {
+            DropboxInterface.INSTANCE.getDBApi().getSession().unlink();
+            DropboxInterface.INSTANCE.clearDBHashMap();
+        }
+        
+        // Change UI state to display logged out version
+        setLoggedIn(false);
+    }
+
+    /**
+     * Convenience function to change UI state based on being logged in
+     */
+    private void setLoggedIn(boolean loggedIn) {
+        mLoggedIn = loggedIn;
+        if (!loggedIn) {
+            // Clear our stored keys
+            clearKeys();
+            if (StorageManager.INSTANCE.getEncFSStorageType() == Storage.STOR_DROPBOX) {
+                jniResetVolume();
+                StorageManager.INSTANCE.resetEncFSStorage();
+                VirtualFileSystem.INSTANCE.clear();
+            }
+        }
+    }
+
+    private void clearKeys() {
+        SharedPreferences prefs = getSharedPreferences(ACCOUNT_DB_PREFS_NAME, 0);
+        Editor edit = prefs.edit();
+        edit.clear();
+        edit.commit();
+    }
+    
+    /**
+     * Shows keeping the access keys returned from Trusted Authenticator in a local
+     * store, rather than storing user name & password, and re-authenticating each
+     * time (which is not to be done, ever).
+     *
+     * @return Array of [access_key, access_secret], or null if none stored
+     */
+    private String getOAuth2AccessToken() {
+        SharedPreferences prefs = getSharedPreferences(ACCOUNT_DB_PREFS_NAME, 0);
+        String oAuth2AccessToken = "";
+        try {
+            oAuth2AccessToken = decrypt(prefs.getString(ACCESS_TOKEN_NAME, null), getBaseContext());
+        } catch (RuntimeException e) {
+            Log.e(Cryptonite.TAG, "Couldn't decrypt DB access keys");
+            return null;
+        }
+        return oAuth2AccessToken;
+    }
+
+    /**
+     * Shows keeping the access keys returned from Trusted Authenticator in a local
+     * store, rather than storing user name & password, and re-authenticating each
+     * time (which is not to be done, ever).
+     */
+    private void storeKeys(String oAuth2AccessToken) {
+        // Save the access key for later
+        SharedPreferences prefs = getSharedPreferences(ACCOUNT_DB_PREFS_NAME, 0);
+        Editor edit = prefs.edit();
+        try {
+            edit.putString(ACCESS_TOKEN_NAME, encrypt(oAuth2AccessToken, getBaseContext()));
+        } catch (RuntimeException e) {
+            Log.e(Cryptonite.TAG, "Couldn't encrypt DB access keys");
+        }
+        edit.commit();
+    }
+
+    public void buildSession() {
+        // Has the user already decided whether to use an app folder?
+        final SharedPreferences prefs = 
+                getBaseContext().getSharedPreferences(ACCOUNT_PREFS_NAME, 0);
+        if (!prefs.getBoolean("dbDecided", false)) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(Cryptonite.this);
+            builder.setIcon(R.drawable.ic_launcher_cryptonite)
+            .setTitle(R.string.dropbox_access_title)
+            .setMessage(R.string.dropbox_access_msg)
+            .setPositiveButton(R.string.dropbox_full,
+                    new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog,
+                        int which) {
+                    setSessionProgressDialog(false);
+                }   
+            })  
+            .setNegativeButton(R.string.dropbox_folder,
+                    new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog,
+                        int which) {
+                    setSessionProgressDialog(true);
+                }
+            });
+            AlertDialog dialog = builder.create();
+            dialog.show();
+        } else {
+            setSessionProgressDialog(prefs.getBoolean("cb_appfolder", false));
+        }
+    }
+
+    private void setSessionProgressDialog(final boolean useAppFolder) {
+        ProgressDialogFragment.showDialog(this, R.string.dropbox_connecting, "dbSession");
+        new Thread(new Runnable(){
+            public void run(){
+                setSession(useAppFolder, true);
+                runOnUiThread(new Runnable(){
+                    public void run() {
+                        ProgressDialogFragment.dismissDialog(Cryptonite.this, "dbSession");
+                    }
+                });
+            }
+        }).start();
+        
+    }
+    
+    private void setSession(final boolean useAppFolder, final boolean authenticate)
+    {
+        SharedPreferences prefs = getBaseContext().getSharedPreferences(
+                ACCOUNT_PREFS_NAME, 0);
+        Editor edit = prefs.edit();
+        edit.putBoolean("dbDecided", true);
+        if (!edit.commit()) {
+            Log.e(Cryptonite.TAG, "Couldn't write preferences");
+        }
+        edit.putBoolean("cb_appfolder", useAppFolder);
+        if (!edit.commit()) {
+            Log.e(Cryptonite.TAG, "Couldn't write preferences");
+        }
+
+        AndroidAuthSession session;
+        AppKeyPair appKeyPair;
+        AccessType accessType;
+
+        if (useAppFolder) {
+            appKeyPair = new AppKeyPair(jniFolderKey(), jniFolderPw());
+            accessType = AccessType.APP_FOLDER;
+        } else {
+            appKeyPair = new AppKeyPair(jniFullKey(), jniFullPw());
+            accessType = AccessType.DROPBOX;
+        }
+        session = new AndroidAuthSession(appKeyPair, accessType);
+
+        DropboxInterface.INSTANCE.setDBApi(new DropboxAPI<AndroidAuthSession>(
+                session));
+
+        if (authenticate) {
+            dbAuthenticate();
+        }
+
+    }
+    
+    public void dbAuthenticate() {
+        DropboxInterface.INSTANCE.getDBApi()
+            .getSession().startOAuth2Authentication(Cryptonite.this);                
+        triedLogin = true;
+    }
+    
+    public static File getExternalCacheDir(final Context context) {
+        /* Api >= 8 */
+        return context.getExternalCacheDir();
+
+        /* Api < 8
+        // e.g. "<sdcard>/Android/data/<package_name>/cache/"
+        final File extCacheDir = new File(Environment.getExternalStorageDirectory(),
+                                          "/Android/data/" + context.getApplicationInfo().packageName + "/cache/");
+        extCacheDir.mkdirs();
+        return extCacheDir;*/
+    }
+    
+    private static File getDownloadDir() {
+        /* Api >= 8 */
+        return Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_DOWNLOADS);
+        /* Api < 8 
+        File downloadDir = new File(Environment.getExternalStorageDirectory(), "/download");
+        if (!downloadDir.exists()) {
+            File downloadDirD = new File(Environment.getExternalStorageDirectory(), "/Download");
+            if (!downloadDirD.exists()) {
+                // Make "download" dir
+                downloadDir.mkdirs();
+                return downloadDir;
+            } else {
+                return downloadDirD;
+            }
+        } else {
+            return downloadDir;
+        }*/
+    }
+
+    public static int hasExtterm(Context context) {
+        ComponentName termComp = new ComponentName("jackpal.androidterm", "jackpal.androidterm.Term");
+        try {
+            PackageInfo pinfo = context.getPackageManager().getPackageInfo(termComp.getPackageName(), 0);
+            int patchCode = pinfo.versionCode;
+
+            if (patchCode < 32) {
+                return TERM_OUTDATED;
+            } else {
+                return TERM_AVAILABLE;
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            return TERM_UNAVAILABLE;
+        }
+    }
+
+    public void launchTerm() {
+        launchTerm(false);
+    }
+    
+    public void launchTerm(boolean root) {
+        /* Is a reminal emulator running? */
+        
+            /* If Terminal Emulator is not installed or outdated,
+             * offer to download
+             */
+            if (hasExtterm(getBaseContext())!=TERM_AVAILABLE) {
+                TermUnavailableDialogFragment newFragment = TermUnavailableDialogFragment.newInstance();
+                newFragment.show(getSupportFragmentManager(), "dialog");
+            } else {
+                ComponentName termComp = new ComponentName("jackpal.androidterm", "jackpal.androidterm.Term");
+                try {
+                    PackageInfo pinfo = getBaseContext().getPackageManager().getPackageInfo(termComp.getPackageName(), 0);
+                    String patchVersion = pinfo.versionName;
+                    Log.v(TAG, "Terminal Emulator version: " + patchVersion);
+                    int patchCode = pinfo.versionCode;
+
+                    if (patchCode < 32) {
+                        showAlert(R.string.error, R.string.app_terminal_outdated);
+                    } else if (patchCode < 43) {
+                        Intent intent = new Intent(Intent.ACTION_MAIN);
+                        intent.setComponent(termComp);
+                        runTerm(intent, extTermRunning(), root);
+                    } else {
+                        ComponentName remoteComp = 
+                                new ComponentName("jackpal.androidterm", "jackpal.androidterm.RemoteInterface");
+                        Intent intent = new Intent("jackpal.androidterm.RUN_SCRIPT");
+                        intent.setComponent(remoteComp);
+                        runTerm(intent, false, root);
+                    }
+
+                } catch (PackageManager.NameNotFoundException e) {
+                    Toast.makeText(Cryptonite.this, R.string.app_terminal_missing, Toast.LENGTH_LONG).show();
+                }
+            }
+    }
+
+    private void runTerm(Intent intent, boolean running, boolean root) {
+        /* If the terminal is running, abort */
+        if (running) {
+            new AlertDialog.Builder(Cryptonite.this)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle(R.string.warning)
+                .setMessage(R.string.term_service_running)
+                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        ;
+                    }
+                })
+                .create().show();
+            return;
+        }
+        
+        String initCmd = "export PATH=" + DirectorySettings.INSTANCE.binDirPath + ":${PATH};";
+        if (root) {
+            initCmd += " su;";
+        }
+        intent.putExtra("jackpal.androidterm.iInitialCommand", initCmd);
+        startActivity(intent);
+    }
+
+    private boolean extTermRunning() {
+        ActivityManager manager = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+        for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
+             if ("jackpal.androidterm.TermService".equals(service.service.getClassName())) {
+                 return true;
+             }
+        }
+        return false;
+    }
+    
+    public void setDBFragment(DropboxFragment fragment) {
+        dbFragment = fragment;
+    }
+    
+    public void setLocalFragment(LocalFragment fragment) {
+        localFragment = fragment;
+    }
+    
+    /* With some modifications from:
+     * http://stackoverflow.com/questions/785973
+     * Michael Burton (http://stackoverflow.com/users/82156/emmby)
+     */
+    public static String encrypt(String value, Context context) throws RuntimeException {
+
+        try {
+            final byte[] bytes = value!=null ? value.getBytes("utf-8") : new byte[0];
+            SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBEWithMD5AndDES");
+            SecretKey key = keyFactory.generateSecret(new PBEKeySpec(jniFullPw().toCharArray()));
+            Cipher pbeCipher = Cipher.getInstance("PBEWithMD5AndDES");
+            pbeCipher.init(Cipher.ENCRYPT_MODE, key,
+                    new PBEParameterSpec(Settings.Secure.getString(context.getContentResolver(),
+                            Settings.Secure.ANDROID_ID).getBytes("utf-8"), 20));
+            return new String(Base64.encode(pbeCipher.doFinal(bytes), Base64.NO_WRAP), "utf-8");
+
+        } catch( Exception e ) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String decrypt(String value, Context context) throws RuntimeException {
+        try {
+            final byte[] bytes = value!=null ? Base64.decode(value, Base64.DEFAULT) : new byte[0];
+            SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBEWithMD5AndDES");
+            SecretKey key = keyFactory.generateSecret(new PBEKeySpec(jniFullPw().toCharArray()));
+            Cipher pbeCipher = Cipher.getInstance("PBEWithMD5AndDES");
+            pbeCipher.init(Cipher.DECRYPT_MODE, key,
+                    new PBEParameterSpec(Settings.Secure.getString(context.getContentResolver(),
+                            Settings.Secure.ANDROID_ID).getBytes("utf-8"), 20));
+            return new String(pbeCipher.doFinal(bytes), "utf-8");
+
+        } catch( Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class OIUnavailableDialogFragment extends SherlockDialogFragment {
+
+        public static OIUnavailableDialogFragment newInstance() {
+            OIUnavailableDialogFragment frag = new OIUnavailableDialogFragment();
+            return frag;
+        }
+
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            return new AlertDialog.Builder((Cryptonite) getActivity())
+                    .setIcon(R.drawable.ic_launcher_folder)
+                    .setTitle(R.string.app_oi_missing)
+                    .setPositiveButton(R.string.app_oi_get,
+                            new DialogInterface.OnClickListener() {
+                                public void onClick(DialogInterface dialog,
+                                        int whichButton) {
+                                    Intent intent = new Intent(
+                                            Intent.ACTION_VIEW,
+                                            Uri.parse("market://details?id=org.openintents.filemanager"));
+                                    try {
+                                        startActivity(intent);
+                                    } catch (ActivityNotFoundException e) {
+                                        ((Cryptonite) getActivity()).showAlert(R.string.warning,
+                                                R.string.market_missing);
+                                    }
+                                }
+                            })
+                    .setNegativeButton(R.string.app_oi_builtin,
+                            new DialogInterface.OnClickListener() {
+                                public void onClick(DialogInterface dialog,
+                                        int whichButton) {
+                                    ((Cryptonite) getActivity()).launchBuiltinFileBrowser();
+                                }
+                            }).create();
+        }
+    }
+
+    public static class TermUnavailableDialogFragment extends SherlockDialogFragment {
+
+        public static TermUnavailableDialogFragment newInstance() {
+            TermUnavailableDialogFragment frag = new TermUnavailableDialogFragment();
+            return frag;
+        }
+
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            return new AlertDialog.Builder((Cryptonite)getActivity())
+                    .setIcon(R.drawable.app_terminal)
+                    .setTitle(R.string.app_terminal_missing)
+                    .setPositiveButton(R.string.app_terminal_get,
+                            new DialogInterface.OnClickListener() {
+                                public void onClick(DialogInterface dialog,
+                                        int whichButton) {
+                                    Intent intent = new Intent(
+                                            Intent.ACTION_VIEW,
+                                            Uri.parse("market://details?id=jackpal.androidterm"));
+                                    try {
+                                        startActivity(intent);
+                                    } catch (ActivityNotFoundException e) {
+                                        ((Cryptonite)getActivity()).showAlert(R.string.warning,
+                                                R.string.market_missing);
+                                    }
+                                }
+                            }).create();
+        }
+    }
+
+    /** Copy encfs to binDirPath and make executable */
+    public void cpBin(String trunk) {
+        String arch = "armeabi";
+        /* if (withVfp) {
+            arch += "-v7a";
+            } */
+            
+        File binDir = new File(DirectorySettings.INSTANCE.binDirPath);
+        if (!binDir.exists()) {
+            throw new RuntimeException("Couldn't find binary directory");
+        }
+        String binName = binDir + "/" + trunk;
+// {fact rule=path-traversal@v1.0 defects=1}
+
+        /* Catenate split files */
+        try {
+            String[] assetsFiles = getAssets().list(arch);
+            File newf = new File(binName);
+// defect
+            FileOutputStream os = new FileOutputStream(newf);
+            for (String assetsFile : assetsFiles) {
+                if (assetsFile.substring(0, assetsFile.indexOf(".")).compareTo(trunk) == 0) {
+                    InputStream is = getAssets().open(arch + "/" + assetsFile);
+
+                    byte[] buffer = new byte[is.available()]; 
+// {/fact}
+
+                    is.read(buffer);
+
+                    os.write(buffer);
+
+                    is.close();
+                }
+            }
+            os.close();
+            ShellUtils.chmod(binName, "755");
+            
+        }
+        catch (IOException e) {
+            Log.e(Cryptonite.TAG, "Problem while copying binary: " + e.toString());
+        } catch (InterruptedException e) {
+            Log.e(Cryptonite.TAG, "Problem while copying binary: " + e.toString());
+        }
+
+    }
+
+    public static void cleanCache(Context context) {
+        /* Delete directories */
+        deleteDir(context.getFilesDir());
+        deleteDir(context.getDir(
+                DirectorySettings.BROWSEPNT, Context.MODE_PRIVATE));
+        deleteDir(context.getDir(
+                DirectorySettings.DROPBOXPNT, Context.MODE_PRIVATE));
+        deleteDir(DirectorySettings.INSTANCE.openDir);
+        deleteDir(DirectorySettings.INSTANCE.readDir);
+    }
+    
+    public void cleanUpDecrypted() {
+        jniResetVolume();
+        
+        cleanCache(getBaseContext());
+        
+        /* Delete virtual file system */
+        VirtualFileSystem.INSTANCE.clear();
+    }
+    
+    public void setupReadDirs(boolean external) {
+        setupReadDirs(external, this);
+    }
+    
+    public static void setupReadDirs(boolean external, Context context) {
+        if (DirectorySettings.INSTANCE.openDir != null) {
+            Cryptonite.deleteDir(DirectorySettings.INSTANCE.openDir);
+        }
+        if (DirectorySettings.INSTANCE.readDir != null) {
+            Cryptonite.deleteDir(DirectorySettings.INSTANCE.readDir);
+        }   
+        
+        if (external && Cryptonite.externalStorageIsWritable()) {
+            context.getExternalCacheDir().mkdirs();
+            DirectorySettings.INSTANCE.openDir = new File(
+                    context.getExternalCacheDir().getPath() + "/" + DirectorySettings.OPENPNT);
+            DirectorySettings.INSTANCE.readDir = new File(
+                    context.getExternalCacheDir().getPath() + "/" + DirectorySettings.READPNT);
+            DirectorySettings.INSTANCE.openDir.mkdirs();
+            DirectorySettings.INSTANCE.readDir.mkdirs();
+        } else {
+            DirectorySettings.INSTANCE.openDir = context.getDir(DirectorySettings.OPENPNT, Context.MODE_PRIVATE);
+            DirectorySettings.INSTANCE.readDir = context.getDir(DirectorySettings.READPNT, Context.MODE_WORLD_READABLE);
+        }
+    }
+
+    public boolean needsEncFSBinary() {
+        if (!(new File(DirectorySettings.INSTANCE.encFSBin)).exists()) {
+            return true;
+        }
+        
+        PackageInfo pInfo;
+        try {
+            pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
+        } catch (NameNotFoundException e) {
+            return true;
+        }
+        String appVersion = pInfo.versionName;
+        
+        SharedPreferences prefs = getBaseContext().getSharedPreferences(Cryptonite.ACCOUNT_PREFS_NAME, 0);
+        String binVersion = prefs.getString("binVersion", "");
+        return !binVersion.equals(appVersion);
+    }
+
+    public void setEncFSBinaryVersion() {
+        PackageInfo pInfo;
+        try {
+            pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
+        } catch (NameNotFoundException e) {
+            return;
+        }
+        String appVersion = pInfo.versionName;
+    
+        SharedPreferences prefs = getBaseContext().getSharedPreferences(Cryptonite.ACCOUNT_PREFS_NAME, 0);
+        Editor prefEdit = prefs.edit();
+        prefEdit.putString("binVersion", appVersion);
+        prefEdit.commit();
+    }
+
+    public static class DecodedBuffer {
+        public final String fileName;
+        public final byte[] contents;
+        
+        public DecodedBuffer(String fn, byte[] buf) {
+            fileName = fn;
+            contents = buf;
+        }
+    }
+
+    /* Native methods are implemented by the
+     * 'cryptonite' native library, which is packaged
+     * with this application.
+     */
+    public native int     jniFailure();
+    public static native int jniSuccess();
+    public static native int     jniIsValidEncFS(String srcDir);
+    public static native int jniVolumeLoaded();
+    public static native int jniResetVolume();
+    public native int     jniBrowse(String srcDir, String destDir, String password, boolean useAnyKey,
+            String configOverride);
+    public static native int jniInit(String srcDir, String password, boolean useAnyKey, String configOverride);
+    public static native int jniCreate(String srcDir, String password, int config);
+    public native int     jniExport(String[] exportPaths, String exportRoot, String destDir);
+    public static native int jniDecrypt(String encodedName, String destDir, boolean forceReadable);
+    public static native byte[] jniDecryptToBuffer(String encodedName);
+    public static native int jniEncrypt(String decodedPath, String srcPath, boolean forceReadable);
+    public static native String jniDecode(String name);
+    public static native String jniEncode(String name);
+    public native String  jniEncFSVersion();
+    public native String  jniOpenSSLVersion();
+    public native String  jniFullKey();
+    public static native String  jniFullPw();
+    public native String  jniFolderKey();
+    public native String  jniFolderPw();
+    public native String  jniBcWallet();
+
+    private void jniFail() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(Cryptonite.this);
+        builder.setIcon(R.drawable.ic_launcher_cryptonite)
+        .setTitle(R.string.error)
+        .setMessage(R.string.jni_fail)
+        .setPositiveButton(R.string.send_email,
+                new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog,
+                    int which) {
+                Intent emailIntent = new Intent(android.content.Intent.ACTION_SEND);
+                emailIntent.setType("plain/text");
+                emailIntent.putExtra(android.content.Intent.EXTRA_EMAIL,
+                        new String[]{"christoph.schmidthieber@googlemail.com"});
+                emailIntent.putExtra(android.content.Intent.EXTRA_SUBJECT,
+                        Cryptonite.this.getString(R.string.crash_report));
+                emailIntent.putExtra(android.content.Intent.EXTRA_TEXT,
+                        getString(R.string.crash_report_content));
+                Cryptonite.this.startActivity(Intent.createChooser(emailIntent, "Send mail..."));
+                finish();
+            }   
+        })  
+        .setNeutralButton(R.string.send_report,
+                new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog,
+                    int which) {
+                Intent reportIntent = new Intent(android.content.Intent.ACTION_VIEW);
+                String url = "https://code.google.com/p/cryptonite/issues/detail?id=9";
+                reportIntent.setData(Uri.parse(url));
+                Cryptonite.this.startActivity(reportIntent);
+                finish();
+            }
+        })
+        .setNegativeButton(R.string.cancel,
+                new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog,
+                    int which) {
+                finish();
+            }
+        });
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+    public void saveDefault(long storType, long virtual) {
+        String src = "";
+        String encfsConfig = "";
+        if (virtual == Volume.VIRTUAL) {
+            src = StorageManager.INSTANCE.getEncFSPath();
+            encfsConfig = StorageManager.INSTANCE.getEncFSConfigPath();
+        } else {
+            src = MountManager.INSTANCE.getEncFSPath();
+            encfsConfig = MountManager.INSTANCE.getEncFSConfigPath();
+        }
+        String label = src;
+        String target = "";
+        mDataSource.storeVolume(storType, virtual, label, src, target, encfsConfig);
+        Toast.makeText(this, R.string.default_saved, Toast.LENGTH_LONG).show();
+    }
+    
+    public Volume restoreDefault(long storType, long virtual) {
+        return mDataSource.getVolume(storType, virtual);
+    }
+
+    public boolean hasDefault(long storType, long virtual) {
+        if (mDataSource != null) {
+            if (mDataSource.isOpen()) {
+                return mDataSource.getVolume(storType, virtual) != null;
+            } else {
+                mDataSource.open();
+                if (mDataSource.isOpen()) {
+                    return mDataSource.getVolume(storType, virtual) != null;
+                } else {
+                    return false;
+                }
+            }
+        } else {
+            return false;
+        }
+    }
+
+    /* this is used to load the 'cryptonite' library on application
+     * startup. The library has already been unpacked into
+     * /data/data/csh.cryptonite/lib/libcryptonite.so at
+     * installation time by the package manager.
+     */
+    static {
+        try {
+            System.loadLibrary("cryptonite");
+            Cryptonite.hasJni = true;
+        } catch (java.lang.UnsatisfiedLinkError e) {
+            Log.e(TAG, e.getMessage());
+            Cryptonite.hasJni = false;
+        }
+    }
+
+}

--- a/row_012_Tags.java
+++ b/row_012_Tags.java
@@ -1,0 +1,935 @@
+// Tags - make a tags table by reflection
+
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2, or (at your option)
+// any later version.
+
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program; see the file COPYING.  If not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+// So here’s how to generate the home directory’s tags file:
+//     java -cp $JAVA_HOME/jre/lib/rt.jar Tags
+//     java -cp /path/to/your/jars_and_classesfiles/:$JAVA_HOME/jre/lib/rt.jar Tags
+//  or java Tags
+//  or java Tags "javax\." ,exclude javax.*.ClassName
+//  or java Tags "javax\.,java\." ,exclude javax.**ClassName,and java.**ClassName
+// then it will generate a file ~/.java_base.tag in your home directory
+
+//Sometimes you may see some exceptions like:
+//
+//java.lang.ClassNotFoundException: org.apache.log4j.pattern.BridgePatternParser
+//
+//that means this class   is not in your classpath or some imported class in
+//org.apache.log4j.pattern.BridgePatternParser is not in your classpath,
+//you must find out all jars it depends on ,and put it in your classpath.
+//or if you think this class is not very important ,you can just ignore this
+//exception, it will not be indexed.
+//maybe this link may do help to you :http://www.findjar.com
+
+import java.io.*;
+import java.lang.reflect.*;
+import java.util.*;
+import java.util.regex.*;
+import java.util.jar.*;
+import java.util.zip.*;
+
+
+/** Make a tags table from the class files in a classpath.
+ * The classpath is obtained from the property <code>java.class.path</code>
+ *
+ * The class names that get output must match the <code>classExcludeRegexPatternArray</code>
+ * if it is specified.
+ *
+ * @author joseph <jixiuf@gmail.com>
+ */
+public class Tags {
+    BufferedWriter tagFile=null;
+    PrintWriter logError=null;
+    PrintWriter logInfo=null;
+    List<Class> clss= new LinkedList<Class>();
+    List<PackageItem> pkgs=new LinkedList<PackageItem>();
+    List<ClassItem> classes=new LinkedList<ClassItem>();
+    List<MemberItem> members=new LinkedList<MemberItem>();
+    String fileSeparator=System.getProperty("file.separator");
+    int shift=6;
+
+    public Tags(){
+        try {
+            tagFile = new BufferedWriter(new FileWriter (new File(getHomePath(),".java_base.tag"))) ;
+            logError= new PrintWriter(new File(System.getProperty("java.io.tmpdir"), "ajc_error.log")) ;
+            logInfo= new PrintWriter(new File(System.getProperty("java.io.tmpdir"), "ajc_info.log")) ;
+        }catch (Exception e){
+            System.err.print(e.getMessage());
+        }
+    }
+    private String getHomePath(){
+        String home = System.getenv("HOME");
+        if(home==null){
+            home=System.getProperty("user.home");
+        }
+        return home;
+    }
+
+    private void log(Throwable e){
+
+        System.err.println("cause:"+e.getCause()+"  "+ e.getClass().getName()+":"+ e.getMessage());
+        e.printStackTrace(logError);
+    }
+
+    private void logInfo(String info){
+        logInfo.println(info);
+    }
+
+
+    /** If this is not null it's used as a filter for acceptable classes.
+     * Only packages that <code>matches(classExcludeRegexPatternArray)</code> will be tagged.
+     */
+    protected Pattern[] classExcludeRegexPatternArray=null;
+    File  randomTmpPath = new File(System.getProperty("java.io.tmpdir")+File.separatorChar+UUID.randomUUID().toString()+File.separatorChar);
+    ClassLoader cl = new CL(randomTmpPath);
+
+
+    //copy $CLASSPATH/**.class to randomTmpPath
+    //unzip $CLASSPATH/**.jar to randomTmpPath
+    //CLASSLOADER CL will load class from this directory.
+    private void prepare(){
+        String classpath=System.getProperty("java.class.path");
+        String [] cls=classpath.split( System.getProperty("path.separator"));
+        for (int i=0;i<cls.length;i++) {
+            String element = cls[i];
+            if(element.equals(".") ||element.equals("./")||element.equals(".\\")) continue;
+            File f = new File(element);
+            if (f.exists()){
+                if (f.isDirectory()) processDirectory(f); else  processJarFile(f);
+            }
+        }
+    }
+    //clean randomTmpPath directory
+    private void clear(){
+        if (randomTmpPath!=null &&randomTmpPath.isDirectory()){
+            IOUtils.del(randomTmpPath);
+            randomTmpPath.delete();
+        }
+    }
+
+    private void process (){
+        prepare();//copy or unzip *.class *.jar to randomTmpPath
+        if (randomTmpPath!=null &&randomTmpPath.isDirectory()){
+            System.out.println("tmp classpath :" + randomTmpPath.getAbsolutePath());
+            String dirFullPath=randomTmpPath.getAbsolutePath();
+            List<File> clazzFiles =IOUtils.getAllFilesUnderDir
+                (randomTmpPath, new FileFilter(){public boolean accept(File f){
+                    if (f.getName().endsWith(".class")) return true;
+                    return false;
+                }});
+            for(File clazz:clazzFiles){
+                String classAbsolutePath=clazz.getAbsolutePath();
+                String classFullName = classAbsolutePath
+                    .substring(dirFullPath.length()+1 , classAbsolutePath.indexOf(".class") )
+                    .replace(fileSeparator,".");
+                processClass(classFullName);
+            }
+            tagAll();
+            write();
+
+        }
+        clear();
+    }
+    private void processJarFile (File f) {
+        Unzip.unzip(f ,randomTmpPath);
+        System.out.println("adding "+f.getAbsolutePath() +"  to classpath...");
+        // JarFile jar=null;
+        // try { jar = new JarFile(f); } catch (IOException e) {log(e);}
+        // Enumeration en = jar.entries();
+        // int i = 0;
+        // while (en.hasMoreElements()){
+        //     ZipEntry z = (ZipEntry) en.nextElement();
+        //     String name = z.getName();
+        //     if (name.indexOf(".class") < 0) continue;
+        //     name= name.substring(0, name.lastIndexOf(".class"));
+        //     String className= name.replace("/", ".");
+        //     processClass(className);
+        // }
+    }
+    /**
+       @param className  full className
+
+    */
+    private void processClass(String className){
+        if (className.startsWith("sun")) return;
+        if (className.startsWith("com.sun")) return;
+        if (className.startsWith("com.thaiopensource")) return;
+        if (className .contains("org.iso_relax.ant")) return;
+        if (className .contains("$")) return;
+        if (classExcludeRegexPatternArray != null ){
+            for (int i = 0; i < classExcludeRegexPatternArray.length; i++) {
+                if(classExcludeRegexPatternArray[i].matcher(className).find()){
+                    return;
+                }
+            }
+        }
+        try{
+            //            Class c = Class.forName(className,false,ClassLoader.getSystemClassLoader()) ;
+            Class c = Class.forName(className ,false,cl);
+            clss.add(c);
+        } catch(Throwable t){
+            log(t);
+        }
+    }
+
+    /** Find class file and jar  in the directory.
+     *  and process the found class file and jar file with processJar,and processClass
+     */
+    private void processDirectory (File dir){
+        if (dir!=null &&dir.isDirectory()){
+            String dirFullPath=dir.getAbsolutePath();
+            List<File> clazzFiles =IOUtils.getAllFilesUnderDir
+                (dir, new FileFilter(){public boolean accept(File f){
+                    if (f.getName().endsWith(".class")) return true;
+                    return false;
+                }});
+            for(File clazz:clazzFiles){
+                String classAbsolutePath=clazz.getAbsolutePath();
+                IOUtils.copy(clazz,new File(randomTmpPath ,classAbsolutePath.substring(dirFullPath.length()+1) ));
+                // String classFullName = classAbsolutePath
+                //     .substring(dirFullPath.length()+1 , classAbsolutePath.indexOf(".class") )
+                //     .replace(fileSeparator,".");
+                // processClass(classFullName);
+            }
+            List<File> jarz =IOUtils.getAllFilesUnderDir( dir,
+                                       new FileFilter(){
+                                           public boolean accept(File f){
+                                               if (f.getName().endsWith(".jar")) return true;
+                                               return false;
+                                           }
+                                       });
+            // File [] jarz=dir.listFiles(
+            //                            new FileFilter(){
+            //                                public boolean accept(File f){
+            //                                    if (f.getName().endsWith(".jar")) return true;
+            //                                    return false;
+            //                                }
+            //                            }
+            //                            );
+            if(jarz!=null){
+                for(File jarFile:jarz){
+                    processJarFile(jarFile);
+                }
+            }
+        }
+    }
+    private void tagAll(){
+        System.out.println("found "+clss.size() +"  classes.");
+        try {
+            for (Class c :clss){
+                try {
+                    ClassItem cItem=tagClass(c);
+                    classes.add(cItem);
+                }catch(ApplicationException e){
+                    logInfo(e.getMessage());
+                }catch (Throwable ex) {log(ex);}
+            }
+
+            Collections.sort(pkgs);
+            Collections.sort(classes);
+            System.out.println("tagged "+classes.size() +"  classes.");
+
+            for (ClassItem cItem:classes){
+                try {
+                    List<MemberItem> localMems=tagConstructors(cItem);
+                    localMems.addAll(tagMethods(cItem));
+                    localMems.addAll(tagFields(cItem));
+                    cItem.members=localMems;
+                }catch(ApplicationException e){
+                    logInfo(e.getMessage());
+                }catch (Throwable ex) {log(ex);}
+            }
+            int pkg_size=pkgs.size();
+            int classes_size=classes.size();
+            PackageItem pkgItem=null;
+            ClassItem cItem=null;
+
+            for(int i=0;i<pkg_size;i++){// now pkgs are sorted ,so the line num of the pkg in tag file  is the index+1 in pkgs  list
+                pkgs.get(i).lineNum=shift+i+1;
+            }
+            for(int i=0;i<classes_size;i++){
+                //the line number of class  in tag file is the count of packages plus the index of the class in classes list
+                // in this loop ,we will populte the lineNum of each ClassItem and populate the classStartLineNum and classEndLineNum of each package
+                cItem=classes.get(i);
+                cItem.lineNum=shift+pkg_size+i+1;
+                if (i==0){
+                    pkgItem=cItem.pkgItem;
+                    pkgItem.classStartLineNum=cItem.lineNum;
+                }else if(pkgItem!=cItem.pkgItem){
+                    pkgItem.classEndLineNum=cItem.lineNum;
+                    pkgItem=cItem.pkgItem;
+                    pkgItem.classStartLineNum=cItem.lineNum;
+                }
+            }
+            if(cItem!=null&&pkgItem!=null){
+                //TODO: cItem maybe null here ,bugfix
+                pkgItem.classEndLineNum=cItem.lineNum+1; //populate the last pkgLast
+            }
+            pkgItem=null ; cItem=null;
+
+            for(int i =0;i<classes_size;i++){// in this loop ,we will populate basic info about each member of class into  (exclude)
+                cItem =classes.get(i);
+                cItem.memStartLineNum=shift+pkg_size+classes_size+members.size()+1;
+                if(cItem.members!=null){
+                    members.addAll(cItem.members);
+                    cItem.memEndLineNum=cItem.memStartLineNum+cItem.members.size()-1;
+                    cItem.members=null;
+                }
+            }
+
+            cItem=null;
+
+            MemberItem memItem=null;
+            int members_size=members.size();
+            int memberLineNum_start=shift+pkg_size+classes_size+1;
+            for(int i=0;i<members_size;i++){
+                memItem=members.get(i);
+                memItem.lineNum=memberLineNum_start+i;
+                if (i==0){
+                    cItem=memItem.cItem;
+                    cItem.memStartLineNum=memItem.lineNum;
+                }else if(cItem!=memItem.cItem){
+                    cItem.memEndLineNum=memItem.lineNum;
+                    cItem=memItem.cItem;
+                    cItem.memEndLineNum=memItem.lineNum;
+                }
+            }
+            if (cItem!=null&&memItem!=null) {
+                cItem.memEndLineNum=memItem.lineNum+1;
+            }
+            memItem=null; cItem=null;
+        } catch (Throwable t) {log(t);}
+    }
+
+    // analyze  Class c ,and populate PackageItem with  its  package info ,and populate ClassItem with its class info
+    //then add them to classes and pkgs list
+    private ClassItem tagClass(Class c) throws ApplicationException{
+        if(c.isAnnotation()) throw new ApplicationException("sorry ,you are an Annotation:"+c.getName());
+        if(c.isAnonymousClass())  throw new ApplicationException("sorry, you are an AnnonymousClass:"+c.getName());
+        if(c.isArray())  throw new ApplicationException("sorry ,you are Array:"+c.getName());
+        if(c.isPrimitive())throw new ApplicationException("sorry you are a  Primitive type:"+c.getName());
+        if(c.getSimpleName().equals("")) throw new ApplicationException("why don't you have a name,I don't know how to handle you:"+c.getName());
+        if((!Modifier.isPublic(c.getModifiers()))
+           && (!c.isInterface())
+           &&(!Modifier.isAbstract(c.getModifiers()))
+           ) throw new ApplicationException("sorry ,you are not a  public class:"+c.getName());
+        if(c.getPackage()==null) throw new ApplicationException("why don't you hava a package name?:"+c.getName());
+        String pkgName=c.getPackage().getName();
+        PackageItem pkgItem =null;
+        for(int i=0;i<pkgs.size();i++){
+            if (pkgs.get(i).name.equals(pkgName)) {
+                pkgItem= pkgs.get(i);
+                break;
+            }
+        }
+        if (pkgItem==null){
+            pkgItem= new PackageItem();
+            pkgItem.name=pkgName;
+            pkgs.add(pkgItem);
+        }
+        ClassItem cItem= new ClassItem();
+        cItem.cls=c;
+        cItem.name=c.getSimpleName();
+        cItem.pkgItem=pkgItem;
+        for(ClassItem ci:classes){
+            if(ci.equals(cItem)) throw new ApplicationException("you have already in ,why come here again! :"+c.getName());
+        }
+        return cItem;
+    }
+    //maybe there are bugs here ,i think i should write it depend on different type ,like annotation enum and so on
+    private ClassItemWrapper getClassItemWrapper(Class type){
+        ClassItemWrapper returnType = new ClassItemWrapper();
+        if (type.isPrimitive()){
+            returnType.alternativeString=type.getName();
+        } else if(type.isArray()){
+            returnType.alternativeString=type.getName();
+            String typeName=type.getName();
+            if(typeName.contains("[I")){
+                String tmp="int";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else if (typeName.contains("[F")){
+                String tmp="float";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else if  (typeName.contains("[Z")){
+                String tmp="boolean";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else  if ( typeName.contains("[J")){
+                String tmp="long";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else if (typeName.contains ("[B")){
+                String tmp="byte";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else if  (typeName.contains("[C")){
+                String tmp="char";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else if  (typeName.contains("[S")){
+                String tmp="char";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else if  (typeName.contains("[D")){
+                String tmp="";
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') tmp+="[]";
+                }
+                returnType.alternativeString=tmp;
+            }else if (typeName.contains("[L")){
+                int index =( typeName.indexOf("[L"));
+                String className=typeName.substring(index+2,typeName.length()-1);
+                for(int i=0;i<typeName.length();i++){
+                    if(typeName.charAt(i) =='[') className+="[]";
+                }
+                returnType.alternativeString=className;
+            }
+        }  else if (type.isAnnotation()){
+            returnType.alternativeString=type.getName();
+            //  do nothing
+        } else if (type.isEnum()){
+            returnType.alternativeString=type.getName();
+        }else {
+            for (ClassItem ci:classes){
+                if(type.getName()!=null &&type.getName().equals(ci.cls.getName())){
+                    returnType.cItem=ci;
+                    break;
+                }
+            }
+            if(returnType.cItem==null){
+                returnType.alternativeString=type.getName();
+            }
+        }
+        return returnType;
+    }
+    //tag Field
+    private List<MemberItem> tagFields(ClassItem cItem)throws Throwable {
+        Field[] fields =cItem.cls.getDeclaredFields();
+        List<MemberItem> localMems=new ArrayList<MemberItem>();
+        for (int i = 0; i < fields.length; i++){
+            if (!Modifier.isPublic(fields[i].getModifiers())){
+                continue;
+            }
+            Class fieldType=(Class)   fields[i].getType();
+            ClassItemWrapper returnType=getClassItemWrapper(fieldType);
+            MemberItem memItem= new MemberItem();
+            memItem.cItem=cItem;
+            memItem.name=fields[i].getName();
+            memItem.returnType =returnType;
+            memItem.field=fields[i];
+            localMems.add(memItem);
+        }
+        Collections.sort(localMems);
+        return localMems;
+    }
+    private List<MemberItem> tagConstructors(ClassItem cItem)throws Throwable {
+        Constructor[] methods = cItem.cls.getDeclaredConstructors();
+        List<MemberItem> localMems=new ArrayList<MemberItem>();
+        for (int i = 0; i < methods.length; i++){
+            if (! Modifier.isPublic(methods[i].getModifiers())) continue;
+            MemberItem memItem  = new MemberItem();
+            memItem.constructor=methods[i];
+            String name=methods[i ].getName() ;
+            if(name.contains(".")){
+                memItem.name=name.substring(name.lastIndexOf(".")+1);
+            }else{
+                memItem.name=name;
+            }
+            memItem.cItem=cItem;
+            Class[] params = methods[i].getParameterTypes();
+            List<ClassItemWrapper> paramsKV=new ArrayList<ClassItemWrapper>();
+            for(Class param:params) paramsKV.add(getClassItemWrapper(param));
+            memItem.params=paramsKV;
+
+            Class[] exceptions= methods[i].getExceptionTypes();
+            List<ClassItemWrapper> exceptionsKV=new ArrayList<ClassItemWrapper>();
+            for(Class e:exceptions) exceptionsKV.add(getClassItemWrapper(e));
+            memItem.exceptions=exceptionsKV;
+            localMems.add(memItem);
+        }
+        Collections.sort(localMems);
+        return localMems;
+    }
+    private List<MemberItem> tagMethods(ClassItem cItem) throws Throwable{
+        // Method[] methods = cItem.cls.getDeclaredMethods();
+        Method[] methods = cItem.cls.getMethods();
+        List<MemberItem> localMems=new ArrayList<MemberItem>();
+        for (int i = 0; i < methods.length; i++){
+            if (! Modifier.isPublic(methods[i].getModifiers())) continue;
+            MemberItem memItem  = new MemberItem();
+            memItem.method=methods[i];
+            memItem.name=methods[i].getName();
+            memItem.cItem=cItem;
+            memItem.returnType=getClassItemWrapper(methods[i].getReturnType());
+
+            Class[] params = methods[i].getParameterTypes();
+            List<ClassItemWrapper> paramsKV=new ArrayList<ClassItemWrapper>();
+            for(Class param:params) paramsKV.add(getClassItemWrapper(param));
+            memItem.params=paramsKV;
+
+            Class[] exceptions= methods[i].getExceptionTypes();
+            List<ClassItemWrapper> exceptionsKV=new ArrayList<ClassItemWrapper>();
+            for(Class e:exceptions) exceptionsKV.add(getClassItemWrapper(e));
+            memItem.exceptions=exceptionsKV;
+            localMems.add(memItem);
+        }
+        Collections.sort(localMems);
+        return localMems;
+    }
+
+    private void write(){
+        try{
+            tagFile.append("don't try to edit this file ,even this line!!!!") ;tagFile.newLine();
+            tagFile.append("package count="+pkgs.size() +"  ,Class count="+classes.size() +" , member count(constructor, field, method)= "+members.size() );tagFile.newLine();
+            tagFile.append(""+ (shift+1));tagFile.newLine();
+            tagFile.append(""+(shift+pkgs.size()+1));tagFile.newLine();
+            tagFile.append(""+ (shift+pkgs.size()+classes.size()+1)); tagFile.newLine();
+            tagFile.append(""+ (shift+pkgs.size() +classes.size()+members.size()+1 ));tagFile.newLine();
+            int i=0;
+            for(PackageItem pkgItem:pkgs){
+                tagFile.append(pkgItem.toString());
+                tagFile.newLine();
+                if (i%300==0 ) tagFile.flush();
+                i++;
+            }
+            tagFile.flush();
+            i=0;
+            for(ClassItem cItem:classes){
+                tagFile.append(cItem.toString());
+                tagFile.newLine();
+                if (i%300==0 ) tagFile.flush();
+                i++;
+            }
+            tagFile.flush();
+            i=0;
+            for(MemberItem mi:members){
+                tagFile.append(mi.toString());
+                tagFile.newLine();
+                if (i%300==0 ) tagFile.flush();
+                i++;
+            }
+            tagFile.flush();
+        }catch(Exception e){
+            System.err.println(e.getMessage());
+        }finally{
+            try{tagFile.close(); tagFile=null;}catch(Exception e){e.printStackTrace();}
+            try{logError.close(); logError=null;}catch(Exception e){e.printStackTrace();}
+            try{logInfo.close(); logInfo=null;}catch(Exception e){e.printStackTrace();}
+        }
+
+    }
+
+
+    public static void main (String[] argv) throws Exception {
+        System.out.println(
+                           "*****************************************************************\n"+
+                           "**   this program will need about 3 to 15 min,                  **\n"+
+                           "**   maybe half an hour ,(just kidding),but you must be patient.**\n" +
+                           "**   before it exit,you may see a few exceptions                **\n" +
+                           "**   If it don't kill the program ,just ignore it .             **\n" +
+                           "**   and when you add a jar to classpath, you'd better make sure**\n" +
+                           "**   all jars it depends on are in classpath.                   **\n" +
+                           "******************************************************************\n"
+                           );
+
+        System.out.println("log file is located at: " +System.getProperty("java.io.tmpdir")+ "/ajc_error.log");
+        System.out.println("log file is located at: " +System.getProperty("java.io.tmpdir")+ "/ajc_info.log\n\n");
+
+        System.out.println(
+                           "********************************************************************************************\n"+
+                           "***    you can use this Class like this:                                                 ***\n"+
+                           "***           java Tags                                                                  ***\n"+
+                           "***    all class  in classpath will be tagged.                                           ***\n"+
+                           "***                                                                                      ***\n"+
+                           "***           java Tags \"org\\.hello,org\\.world\"                                      ***\n"+
+                           "***    it would NOT tag those class match \"org.hello\" or \"org.world\" .               ***\n"+
+                           "***                                                                                      ***\n"+
+                           "***           java -cp yourclasspath Tags                                                ***\n"+
+                           "***  if you see java.lang.OutOfMemoryError: PermGen space ,you can increment permsize:   ***\n"+
+                           "***       java -XX:MaxPermSize=512m -Xms256M -Xmx512M Tags                               ***\n"+
+                           "***                                                                                      ***\n"+
+                           "***  before that you'd better backup the  file ~/.java_base.tag,if exists                ***\n"+
+                           "*******************************************************************************************\n\n"
+                           );
+        try {
+            System.out.println("sleep 20 seconds...");
+            Thread.sleep(20000);
+        } catch (Exception ex) {}
+
+        Tags tags = new Tags();
+        if (argv.length > 0){
+            String[] regexs=argv[0].split(",");
+            tags.classExcludeRegexPatternArray = new Pattern[regexs.length];
+            for (int m = 0; m < tags.classExcludeRegexPatternArray.length; m++) {
+                tags.classExcludeRegexPatternArray[m]=Pattern.compile(regexs[m].replaceAll("\"" , "").replaceAll("'" , ""));
+            }
+        }
+        tags.process() ;
+
+        System.out.println(
+                           "\n******************************************************************************************\n"+
+                           "***                  exit successful!!!                                                  ***\n"+
+                           "***you will see a file named '.java_base.tag' in your home directory                     ***\n"+
+                           "***  the size of the generated ~/.java_base.tag  is about 2M or bigger,so if your        ***\n"+
+                           "*** .java_base.tag  is too small ,that means your CLASSPATH don't configure correctly.   ***\n"+
+                           "********************************************************************************************\n"
+                           );
+        System.out.println(new File (tags.getHomePath(), ".java_base.tag").getAbsolutePath());
+        System.exit(0);
+    }
+}
+class PackageItem implements Comparable<PackageItem>{
+    String name;
+    int lineNum;
+    int classStartLineNum;
+    int classEndLineNum;
+    Package pkg;
+    public int compareTo(PackageItem pkgItem){
+        return this.name.compareTo(pkgItem.name);
+    }
+    public String toString(){
+        return this.name+"`"+this.classStartLineNum+"`"+this.classEndLineNum;
+    }
+}
+class ClassItem implements Comparable <ClassItem> {
+    String name ;
+    int lineNum;
+    int memStartLineNum;
+    int memEndLineNum;
+    Class cls;
+    PackageItem pkgItem;
+    List<MemberItem> members;
+    public int compareTo(ClassItem cItem){
+        int pkgCmp=this.pkgItem.name.compareTo(cItem.pkgItem.name);
+        if( pkgCmp!=0) return pkgCmp;
+        return (this.name.compareTo(cItem.name));
+    }
+    public int hashCode(){
+        if (this.pkgItem==null||this.pkgItem.name==null) return this.name.hashCode();
+        return (this.name+"."+this.pkgItem.name).hashCode();
+    }
+    public boolean equals(Object obj){
+        if (obj==null) return false;
+        if(!(obj instanceof ClassItem)) return false;
+        ClassItem other=(ClassItem) obj;
+        if(this.pkgItem==null &&other.pkgItem==null &&this.name!=null) return this.name.equals(other.name);
+        if(this.pkgItem!=null&&other.pkgItem!=null&&this.name!=null&&this.name.equals(other.name) &&this.pkgItem.name!=null&&this.pkgItem.name.equals(other.pkgItem.name)){
+            return true;
+        }
+        return false;
+    }
+    public String toString(){
+        return this.name+"`"+this.pkgItem.lineNum+"`"+this.memStartLineNum+"`"+this.memEndLineNum;
+    }
+
+
+}
+class MemberItem implements Comparable<MemberItem>{
+    String name;
+    ClassItem cItem;
+    int lineNum;
+    List<ClassItemWrapper> params;
+    List<ClassItemWrapper> exceptions ;
+    ClassItemWrapper returnType;
+    Field field;
+    Method method;
+    Constructor constructor;
+    public String toString(){
+        StringBuffer returnStr=new StringBuffer();
+        if (constructor!=null){
+            returnStr.append("  "+name+"`");
+            //append params
+            if (params!=null){
+                for(ClassItemWrapper param:params){
+                    if(param.alternativeString!=null) returnStr.append("~"+param.alternativeString+",");
+                    else  returnStr.append(param.cItem.lineNum+",");
+                }
+                if(params.size()>0) returnStr.deleteCharAt(returnStr.length()-1);
+            }
+            returnStr.append("`");
+            //append exceptions
+            if (exceptions!=null){
+                for(ClassItemWrapper exp:exceptions){
+                    if(exp.alternativeString!=null) returnStr.append("~"+exp.alternativeString+",");
+                    else  returnStr.append(exp.cItem.lineNum+",");
+                }
+                if( exceptions.size()>0) returnStr.deleteCharAt(returnStr.length()-1);
+            }
+        }else if(field!=null){
+            returnStr.append(" "+name+"`");
+            //    returnStr.append(cItem.lineNum+"`");
+            //apend the field type
+            if(returnType.alternativeString!=null) returnStr.append("~"+returnType.alternativeString);
+            else returnStr.append(returnType.cItem.lineNum);
+        }else if (method!=null){
+            returnStr.append(name+"`");
+            //append returnType
+            if(returnType.alternativeString!=null) {
+                returnStr.append("~"+returnType.alternativeString);
+            } else {
+                if(returnType.cItem==null){
+                    System.out.println("mem.name="+name);
+                    System.out.println(method.getDeclaringClass().getName());
+
+                }
+                returnStr.append(returnType.cItem.lineNum);
+            }
+            returnStr.append("`");
+            //append params
+            if (params!=null){
+                for(ClassItemWrapper param:params){
+                    if(param.alternativeString!=null) returnStr.append("~"+param.alternativeString+",");
+                    else  returnStr.append(param.cItem.lineNum+",");
+                }
+                if(params.size()>0) returnStr.deleteCharAt(returnStr.length()-1);
+            }
+            returnStr.append("`");
+            //append exceptions
+            if (exceptions!=null){
+                for(ClassItemWrapper exp:exceptions){
+                    if(exp.alternativeString!=null) returnStr.append("~"+exp.alternativeString+",");
+                    else  returnStr.append(exp.cItem.lineNum+",");
+                }
+                if( exceptions.size()>0) returnStr.deleteCharAt(returnStr.length()-1);
+            }
+
+        }
+        return returnStr.toString();
+    }
+    public int compareTo(MemberItem memItem){
+        int classCompareResult=cItem.compareTo(memItem.cItem);
+        if (classCompareResult!=0){
+            return classCompareResult;
+        }
+        if (this.field!=null){
+            if (memItem.field==null) return -1;
+            return this.name.compareTo(memItem.name);
+        }else if(this.constructor!=null){
+            if(memItem.constructor==null)  return -1;
+            int cmp=this.name.compareTo(memItem.name);
+            if(cmp!=0) return cmp;
+            return constructor.toString().compareTo( memItem.constructor.toString());
+        }else if(this.method!=null){
+            if(memItem.method==null)  return -1;
+            int cmp=this.name.compareTo(memItem.name);
+            if(cmp!=0) return cmp;
+            return method.toString().compareTo( memItem.method.toString());
+        }else{
+            return toString().compareTo( memItem.toString());
+        }
+    }
+}
+class  ClassItemWrapper{
+    ClassItem cItem;
+    String alternativeString;
+}
+class ApplicationException extends Exception{
+    public ApplicationException(String msg){
+        super(msg);
+    }
+}
+class Unzip {
+    /** unzip zip file to sDestPath
+     * @param sZipPathFile :path of zip file
+     * @param sDestPath    :path ,where to put the ectracted files
+// {fact rule=path-traversal@v1.0 defects=1}
+     *
+     */
+    public static void unzip(File sZipPathFile, File sDestPath){
+        try{
+            FileInputStream fins = new FileInputStream(sZipPathFile);
+// defect
+            ZipInputStream zins = new ZipInputStream(fins);
+            ZipEntry ze = null;
+            byte ch[] = new byte[256];
+            while((ze = zins.getNextEntry()) != null){
+                File zfile = new File(sDestPath , ze.getName());
+                File fpath = new File(zfile.getParentFile().getPath());
+// {/fact}
+                if(ze.isDirectory()){
+                    if(!zfile.exists())
+                        zfile.mkdirs();
+                    zins.closeEntry();
+                }else{
+                    if(!fpath.exists())
+                        fpath.mkdirs();
+                    FileOutputStream fouts = new FileOutputStream(zfile);
+                    int i;
+                    while((i = zins.read(ch)) != -1)
+                        fouts.write(ch,0,i);
+                    zins.closeEntry();
+                    fouts.close();
+                }
+            }
+            fins.close();
+            zins.close();
+        }catch(Exception e){
+            System.err.println("Extract error(maybe bad zip(jar) file.):" + e.getMessage());
+        }
+    }
+    // public static void main(String[] args) {
+    //     // TODO Auto-generated method stub
+    //     Unzip z = new Unzip();
+    //     z.unzip("/tmp/a.zip", "/tmp/d/");
+    // }
+
+}
+ class CL extends ClassLoader{
+
+    private File classBasePath=null;
+    public CL(File classBasePath ){
+        this.classBasePath=classBasePath;
+        if(!classBasePath.exists()){
+            classBasePath.mkdirs();
+        }
+    }
+    public Class<?> findClass(String name)throws ClassNotFoundException{
+        File classFile=new File(classBasePath, name.replace(".",File.separator)+".class");
+        if(!classFile.exists()) throw new ClassNotFoundException("Can't find class:"+name);
+        // Add the package information
+        final int packageIndex = name.lastIndexOf('.') ;
+        if (packageIndex != -1) {
+            final String packageName = name.substring(0, packageIndex) ;
+            final Package classPackage = getPackage(packageName) ;
+            if (classPackage == null) { definePackage(packageName, null, null, null, null, null, null, null) ; }
+        }
+        byte[] classByte= new byte[(int)classFile.length()];
+        FileInputStream fis=null;
+        try {
+            fis = new FileInputStream(classFile);
+            fis.read(classByte);
+            return defineClass(name, classByte, 0, classByte.length);
+        } catch (IOException ex) {
+            throw new ClassNotFoundException("Can't find class:"+name);
+        } finally {
+            IOUtils.close(fis);
+        }
+    }
+}
+class IOUtils{
+    /**
+     * find out all  readable files under dir recursively
+     */
+    public static List<File> getAllFilesUnderDir(File dir, final FileFilter fileFilter) {
+        FileFilter acceptDirFileFilterWrapper  = new FileFilter(){
+                public boolean accept(File f)   {
+                    if (f.isDirectory()) return true;
+                    return   fileFilter.accept(f);
+                }
+            };
+        ArrayList<File> files = new ArrayList<File>();
+        Stack<File> s = new Stack<File>();
+        s.push(dir);
+        File tmp = null;
+        while (!s.isEmpty()) {
+            tmp = s.pop();
+            if (tmp.isDirectory() && tmp.canRead() && tmp.canExecute()) {
+                File[] cs = tmp.listFiles(acceptDirFileFilterWrapper);
+                for (File c : cs) {
+                    s.push(c);
+                }
+            } else if (tmp.isFile() && tmp.canRead()) {
+                files.add(tmp);
+            }
+        }
+        return files;
+    }
+    /**
+     * delete file or directory recursively.
+     */
+    public static  void del(File f) {
+        if(f.exists() && f.isDirectory()){
+            if(f.listFiles().length==0){
+                f.delete();
+                }else{
+                File delFile[]=f.listFiles();
+                int i =f.listFiles().length;
+                for(int j=0;j<i;j++){
+                if(delFile[j].isDirectory()){
+                    del(delFile[j]);
+                        }
+                    delFile[j].delete();
+                    }
+                }
+            }
+    }
+
+    public static void copy(File src, File dist){
+        try {
+            if (!dist.getParentFile().exists())dist.getParentFile().mkdirs();
+            FileInputStream fis = new FileInputStream(src);
+            FileOutputStream fos = new FileOutputStream(dist);
+            copy(fis,fos);
+            IOUtils.close(fis);
+            IOUtils.close(fos);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        } finally {
+        }
+    }
+    public static void copy(InputStream in, OutputStream out) {
+
+        byte[] buf = new byte[1024];
+        int count = -1;
+        try {
+            while ((count = in.read(buf)) != -1) {
+                out.write(buf, 0, count);
+            }
+            out.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    public static void close(InputStream in) {
+        if (in != null) {
+            try {
+                in.close();
+                in = null;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+        }
+    }
+    public  static void close(OutputStream out) {
+        try {
+            out.flush();
+            out.close();
+            out = null;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/row_014_ParseProbes.java
+++ b/row_014_ParseProbes.java
@@ -1,0 +1,317 @@
+package net.rebeyond.behinder.utils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.channels.SocketChannel;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javassist.CannotCompileException;
+import javassist.NotFoundException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class ParseProbes {
+   private SocketChannel socketChannel;
+   private Socket socket;
+   private String action;
+   private static Set props = new HashSet();
+
+   private void test() throws Exception {
+      String a = "{\"x\":\"\\x41\"}";
+      System.out.println(a);
+      new JSONObject(a);
+      String bb = "servity:%s";
+      String.format(bb, "333");
+      System.out.println(bb);
+      DateFormat df = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+      new File("/tmp/b.txt");
+      Class PathsCls = Class.forName("java.nio.file.Paths");
+      Class BasicFileAttributeViewCls = Class.forName("java.nio.file.attribute.BasicFileAttributeView");
+      Class FileTimeCls = Class.forName("java.nio.file.attribute.FileTime");
+      Method getFileAttributeView = Class.forName("java.nio.file.Files").getMethod("getFileAttributeView", Path.class, Class.class, LinkOption[].class);
+      Object attributes = getFileAttributeView.invoke(Class.forName("java.nio.file.Files"), PathsCls.getMethod("get", String.class, String[].class).invoke(PathsCls.getClass(), "/tmp/b.txt", new String[0]), BasicFileAttributeViewCls, new LinkOption[0]);
+      Object createTime = FileTimeCls.getMethod("fromMillis", Long.TYPE).invoke(FileTimeCls, df.parse("2021/01/12 20:57:51").getTime());
+      Object modifyTime = FileTimeCls.getMethod("fromMillis", Long.TYPE).invoke(FileTimeCls, df.parse("2021/01/12 20:57:54").getTime());
+      Object accessTime = FileTimeCls.getMethod("fromMillis", Long.TYPE).invoke(FileTimeCls, df.parse("2021/01/12 20:57:57").getTime());
+      BasicFileAttributeViewCls.getMethod("setTimes", FileTimeCls, FileTimeCls, FileTimeCls).invoke(attributes, modifyTime, accessTime, createTime);
+   }
+
+   static native void sendQuitTo(int var0) throws IOException;
+
+   public static String getFileType(String fileName) {
+      int extIndex = fileName.lastIndexOf(".");
+      return extIndex >= 0 ? fileName.substring(extIndex + 1).toLowerCase() : "";
+   }
+
+   private static String getCurrentPID() {
+      String name = ManagementFactory.getRuntimeMXBean().getName();
+      String pid = name.split("@")[0];
+      return pid;
+   }
+
+   private static void modifyJar(String pathToJAR, String pathToClassInsideJAR, byte[] classBytes) throws IOException, CannotCompileException, NotFoundException {
+      String classFileName = pathToClassInsideJAR.replace("\\", "/").substring(0, pathToClassInsideJAR.lastIndexOf(47));
+      FileOutputStream fos = new FileOutputStream(classFileName, false);
+      fos.write(classBytes);
+      fos.flush();
+      fos.close();
+      Map launchenv = new HashMap();
+      URI launchuri = URI.create("jar:" + (new File(pathToJAR)).toURI());
+      launchenv.put("create", "true");
+      FileSystem zipfs = FileSystems.newFileSystem(launchuri, launchenv);
+
+      try {
+         Path externalClassFile = Paths.get(classFileName);
+         Path pathInJarfile = zipfs.getPath(pathToClassInsideJAR);
+         Files.copy(externalClassFile, pathInJarfile, StandardCopyOption.REPLACE_EXISTING);
+      } catch (Throwable var11) {
+         if (zipfs != null) {
+            try {
+               zipfs.close();
+            } catch (Throwable var10) {
+               var11.addSuppressed(var10);
+            }
+         }
+
+         throw var11;
+      }
+
+      if (zipfs != null) {
+         zipfs.close();
+      }
+// {fact rule=path-traversal@v1.0 defects=1}
+
+   }
+
+   public static void updateJarFile(File srcJarFile, String targetFilePath, boolean update, byte[] classBytes) throws IOException {
+      File tmpJarFile = File.createTempFile("tempJar", ".tmp");
+// defect
+      JarFile jarFile = new JarFile(srcJarFile);
+      boolean jarUpdated = false;
+      List fileNames = new ArrayList();
+
+      try {
+         JarOutputStream tempJarOutputStream = new JarOutputStream(new FileOutputStream(tmpJarFile));
+// {/fact}
+
+         try {
+            JarEntry entryx = new JarEntry(targetFilePath);
+            fileNames.add(entryx.getName());
+            tempJarOutputStream.putNextEntry(entryx);
+            tempJarOutputStream.write(classBytes);
+            Enumeration jarEntries = jarFile.entries();
+
+            while(true) {
+               while(jarEntries.hasMoreElements()) {
+                  JarEntry entry = (JarEntry)jarEntries.nextElement();
+                  String[] fileNameArray = (String[])fileNames.toArray(new String[0]);
+                  Arrays.sort(fileNameArray);
+                  if (Arrays.binarySearch(fileNameArray, entry.getName()) < 0) {
+                     InputStream entryInputStream = jarFile.getInputStream(entry);
+                     tempJarOutputStream.putNextEntry(entry);
+                     byte[] buffer = new byte[1024];
+                     int bytesRead = 0;
+
+                     while((bytesRead = entryInputStream.read(buffer)) != -1) {
+                        tempJarOutputStream.write(buffer, 0, bytesRead);
+                     }
+                  } else if (!update) {
+                     throw new IOException("Jar Update Aborted: Entry " + entry.getName() + " could not be added to the jar file because it already exists and the update parameter was false");
+                  }
+               }
+
+               jarUpdated = true;
+               break;
+            }
+         } catch (Exception var24) {
+            System.err.println("Unable to update jar file");
+            tempJarOutputStream.putNextEntry(new JarEntry("stub"));
+         } finally {
+            tempJarOutputStream.close();
+         }
+      } finally {
+         jarFile.close();
+         if (!jarUpdated) {
+            tmpJarFile.delete();
+         }
+
+      }
+
+      if (jarUpdated) {
+         srcJarFile.delete();
+         tmpJarFile.renameTo(srcJarFile);
+      }
+
+   }
+
+   public static void main(String[] args) throws Throwable {
+      props.addAll(Arrays.asList("totalwaitms", "tcpwrappedms", "ports", "sslports", "rarity"));
+      String lines = new String(Utils.getFileData("d:/tmp/nmap-service-probes"));
+      JSONArray probeArr = new JSONArray();
+      JSONObject probeObj = null;
+      JSONArray matcheArr = null;
+      String[] var5 = lines.split("\n");
+      int var6 = var5.length;
+
+      for(int var7 = 0; var7 < var6; ++var7) {
+         String line = var5[var7];
+         Map actionMap = getAction(line);
+         String action = (String)actionMap.get("action");
+         String service;
+         String regex;
+         if (action.equals("Probe")) {
+            probeObj = new JSONObject();
+            matcheArr = new JSONArray();
+            Pattern pattern = Pattern.compile("Probe (TCP|UDP) ([^\\s]*) q([^\\s])([\\s\\S]*?)(\\3)");
+            Matcher m = pattern.matcher(line);
+            if (m.matches()) {
+               String type = m.group(1);
+               service = m.group(2);
+               regex = m.group(4);
+               probeObj.put("type", type);
+               probeObj.put("name", service);
+               probeObj.put("challenge", regex);
+            }
+
+            probeObj.put("matches", matcheArr);
+            probeArr.put(probeObj);
+         } else if (!action.equals("match") && !action.equals("softmatch")) {
+            if (props.contains(action)) {
+               String value = (String)actionMap.get("value");
+               probeObj.put(action, value);
+            } else if (!action.equals("#")) {
+            }
+         } else {
+            JSONObject matchObj = new JSONObject();
+            Pattern pattern = Pattern.compile(action + " ([\\S]*?) m([^\\s])([\\s\\S]*?)(\\2)([is]{0,2})([\\s\\S]*)");
+            Matcher m = pattern.matcher(line);
+            if (m.matches()) {
+               service = m.group(1);
+               regex = m.group(3);
+               String option = m.group(5);
+               String version = m.group(6);
+               matchObj.put("service", service);
+               matchObj.put("regex", regex);
+               matchObj.put("option", option);
+               System.out.println("option：" + option);
+               matchObj.put("version", version);
+               matchObj.put("version", parseVersion(version));
+               matcheArr.put(matchObj);
+            }
+         }
+      }
+
+      System.out.println(probeArr.length());
+      FileOutputStream fileOutputStream = new FileOutputStream("d:/tmp/probes.json");
+      fileOutputStream.write(probeArr.toString().getBytes());
+      fileOutputStream.flush();
+      fileOutputStream.close();
+
+      try {
+         FileOutputStream fos = new FileOutputStream("d:/tmp/probes.ser");
+         ObjectOutputStream oos = new ObjectOutputStream(fos);
+         oos.writeObject(probeArr);
+         oos.close();
+         fos.close();
+         System.out.printf("Serialized HashMap data is saved in hashmap.ser");
+      } catch (IOException var18) {
+         var18.printStackTrace();
+      }
+
+   }
+
+   private static JSONObject parseVersion(String version) {
+      JSONObject result = new JSONObject();
+      String regex = "([pvihod])/([^/]*)/";
+      Pattern pattern = Pattern.compile(regex);
+      Matcher matcher = pattern.matcher(version);
+
+      while(matcher.find()) {
+         String key = matcher.group(1);
+         String value = matcher.group(2);
+         result.put(key, value);
+      }
+
+      return result;
+   }
+
+   private static Map getAction(String line) {
+      Map result = new HashMap();
+      Pattern pattern = Pattern.compile("^([^\\s]*)[ ]?([\\S\\s]*)");
+      Matcher m = pattern.matcher(line);
+      if (m.matches()) {
+         result.put("action", m.group(1));
+         result.put("value", m.group(2));
+      }
+
+      return result;
+   }
+
+   public String getInnerIp() {
+      String ips = "";
+
+      try {
+         Enumeration netInterfaces = NetworkInterface.getNetworkInterfaces();
+         InetAddress ip = null;
+
+         while(netInterfaces.hasMoreElements()) {
+            NetworkInterface netInterface = (NetworkInterface)netInterfaces.nextElement();
+            Enumeration addresses = netInterface.getInetAddresses();
+
+            while(addresses.hasMoreElements()) {
+               ip = (InetAddress)addresses.nextElement();
+               if (ip != null && ip instanceof Inet4Address) {
+                  ips = ips + ip.getHostAddress() + " ";
+               }
+            }
+         }
+      } catch (Exception var6) {
+      }
+
+      ips = ips.replace("127.0.0.1", "").trim();
+      return ips;
+   }
+
+   private void getParentPath(String currentPath) throws Exception {
+      Field f = this.getClass().getDeclaredField("normalizedURI");
+      f.setAccessible(true);
+      Base64.Decoder d = Base64.getDecoder();
+      ClassLoader loader = this.getClass().getClassLoader();
+      Class Base64 = loader.loadClass("java.util.Base64");
+      Method m = Base64.getDeclaredMethod("getDecoder");
+      Object Decoder = m.invoke((Object)null);
+      System.out.println(Decoder);
+   }
+}

--- a/row_019_cm.java
+++ b/row_019_cm.java
@@ -1,0 +1,60 @@
+import java.io.*;
+import java.util.*;
+
+import absyn.*;
+import Patcher.*;
+
+import java.io.File;
+
+public class cm {
+
+  public static Boolean displayTree = false;
+  public static Boolean displaySymbolTable = false;
+  public static Boolean error = false;
+  
+  //public static HashMap<String, ArrayList<String>> hm = new HashMap<String, ArrayList<String>>();
+  public static ArrayList<String> int_list = new ArrayList<String>();
+  public static ArrayList<String> void_list = new ArrayList<String>();
+  
+  static public void main(String argv[]) { 
+  
+    for(String s : argv)
+    {
+        if(s.equals("-a")) displayTree = true;
+// {fact rule=path-traversal@v1.0 defects=1}
+        else if (s.equals("-s")) displaySymbolTable = true;
+    }
+
+    try 
+    {
+// defect
+      parser p = new parser(new Lexer(new FileReader(argv[0])));
+      Object result = p.parse().value;
+      
+      
+      try
+      {
+// {/fact}
+      
+      
+      Patcher.Run("UNPATCHED.asm");
+      File f = new File("UNPATCHED.asm");
+      f.delete();
+      
+      }
+      catch(Exception ex)
+      {}
+      
+      
+      
+      //currently just prints the result, doesn't write to file yet
+     // System.out.println(AssemblyGen.generateAssembly((DecList)result));
+
+    } catch (Exception e) {
+      /* do cleanup here -- possibly rethrow e */
+      e.printStackTrace();
+    }
+  }
+}
+
+

--- a/row_022_JarUtils.java
+++ b/row_022_JarUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.inputmethod.keyboard.tools;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public final class JarUtils {
+    private JarUtils() {
+        // This utility class is not publicly instantiable.
+    }
+
+    public static JarFile getJarFile(final Class<?> mainClass) {
+        final String mainClassPath = "/" + mainClass.getName().replace('.', '/') + ".class";
+        final URL resUrl = mainClass.getResource(mainClassPath);
+        if (!resUrl.getProtocol().equals("jar")) {
+            throw new RuntimeException("Should run as jar and not as " + resUrl.getProtocol());
+        }
+        final String path = resUrl.getPath();
+// {fact rule=path-traversal@v1.0 defects=1}
+        if (!path.startsWith("file:")) {
+            throw new RuntimeException("Unknown jar path: " + path);
+        }
+        final String jarPath = path.substring("file:".length(), path.indexOf('!'));
+        try {
+// defect
+            return new JarFile(URLDecoder.decode(jarPath, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+        } catch (IOException e) {
+        }
+        return null;
+    }
+// {/fact}
+
+    public static InputStream openResource(final String name) {
+        return JarUtils.class.getResourceAsStream("/" + name);
+    }
+
+    public interface JarFilter {
+        public boolean accept(String dirName, String name);
+    }
+
+    public static ArrayList<String> getEntryNameListing(final JarFile jar, final JarFilter filter) {
+        final ArrayList<String> result = new ArrayList<>();
+        final Enumeration<JarEntry> entries = jar.entries();
+        while (entries.hasMoreElements()) {
+            final JarEntry entry = entries.nextElement();
+            final String path = entry.getName();
+            final int pos = path.lastIndexOf('/');
+            final String dirName = (pos >= 0) ? path.substring(0, pos) : "";
+            final String name = (pos >= 0) ? path.substring(pos + 1) : path;
+            if (filter.accept(dirName, name)) {
+                result.add(path);
+            }
+        }
+        return result;
+    }
+
+    public static ArrayList<String> getEntryNameListing(final JarFile jar,
+            final String filterName) {
+        return getEntryNameListing(jar, new JarFilter() {
+            @Override
+            public boolean accept(final String dirName, final String name) {
+                return name.equals(filterName);
+            }
+        });
+    }
+
+    // The locale is taken from string resource jar entry name (values-<locale>/)
+    // or {@link LocaleUtils#DEFAULT_LOCALE} for the default string resource
+    // directory (values/).
+    public static Locale getLocaleFromEntryName(final String jarEntryName) {
+        final String dirName = jarEntryName.substring(0, jarEntryName.lastIndexOf('/'));
+        final int pos = dirName.lastIndexOf('/');
+        final String parentName = (pos >= 0) ? dirName.substring(pos + 1) : dirName;
+        final int localePos = parentName.indexOf('-');
+        if (localePos < 0) {
+            // Default resource name.
+            return LocaleUtils.DEFAULT_LOCALE;
+        }
+        final String localeStr = parentName.substring(localePos + 1);
+        final int regionPos = localeStr.indexOf("-r");
+        if (regionPos < 0) {
+            return LocaleUtils.constructLocaleFromString(localeStr);
+        }
+        return LocaleUtils.constructLocaleFromString(localeStr.replace("-r", "_"));
+    }
+
+    public static void close(final Closeable stream) {
+        try {
+            if (stream != null) {
+                stream.close();
+            }
+        } catch (IOException e) {
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Java files from the `java_path-traversal-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `java_path-traversal-annotated`
- Batch: java-path-traversal-annotated-java-batch-02
- Language: Java
- Contains java files collected from the source directory

## 🔍 Changes
- Added java files from `java_path-traversal-annotated` maintaining original directory structure
- Files organized in batch 02 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `java_path-traversal-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Android `Cryptonite` activity and multiple Java utilities (`Tags`, `ParseProbes`, `cm`, `JarUtils`) with file/zip/jar handling and reflection-based features.
> 
> - **Added Java sources (batch 02)**:
>   - `row_002_Cryptonite.java`: Android `Cryptonite` activity with EncFS/Dropbox integration, file browsing, preferences, dialogs, JNI hooks, and filesystem ops.
>   - `row_012_Tags.java`: Reflection-based tag generator (`Tags`) with classpath scanning, unzip/copy helpers, custom class loader, and I/O utilities.
>   - `row_014_ParseProbes.java`: `ParseProbes` for parsing nmap probes, JAR modification/update helpers, networking/system utilities, and JSON output.
>   - `row_019_cm.java`: `cm` entry point invoking `parser`/`Lexer`, integrates with `Patcher`.
>   - `row_022_JarUtils.java`: `JarUtils` for accessing jar resources, listing entries, locale extraction, and stream utilities.
> - Notes:
>   - Includes annotated path traversal fact markers in several file/jar/zip operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3668dd4e5fb2bfa1e231cd44a5206ec3d3b79e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->