### PR TITLE
Add Javascript Files from javascript_os-command-injection-annotated - Batch 01

### DIFF
--- a/row_001_find_vuln7.js
+++ b/row_001_find_vuln7.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router()
+// {fact rule=os-command-injection@v1.0 defects=1}
+
+const { exec, spawn }  = require('child_process');
+
+
+router.post('/ping', (req,res) => {
+// defect
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+// {/fact}
+    
+})
+
+router.post('/gzip', (req,res) => {
+    exec(
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+          console.log('err: ', err)
+          console.log('data: ', data);
+          res.send('done');
+    });
+})
+
+router.get('/run', (req,res) => {
+   let cmd = req.params.cmd;
+   runMe(cmd,res)
+});
+
+function runMe(cmd,res){
+//    return spawn(cmd);
+
+    const cmdRunning = spawn(cmd, []);
+    cmdRunning.on('close', (code) => {
+        res.send(`child process exited with code ${code}`);
+    });
+}
+
+module.exports = router

--- a/row_009_exec.js
+++ b/row_009_exec.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router()
+
+const { exec, spawn }  = require('child_process');
+
+
+router.post('/ping', (req,res) => {
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+// {fact rule=os-command-injection@v1.0 defects=1}
+    
+})
+
+router.post('/gzip', (req,res) => {
+    exec(
+// defect
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+          console.log('err: ', err)
+          console.log('data: ', data);
+          res.send('done');
+    });
+// {/fact}
+})
+
+router.get('/run', (req,res) => {
+   let cmd = req.params.cmd;
+   runMe(cmd,res)
+});
+
+function runMe(cmd,res){
+//    return spawn(cmd);
+
+    const cmdRunning = spawn(cmd, []);
+    cmdRunning.on('close', (code) => {
+        res.send(`child process exited with code ${code}`);
+    });
+}
+
+module.exports = router

--- a/row_010_exec.js
+++ b/row_010_exec.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router()
+// {fact rule=os-command-injection@v1.0 defects=1}
+
+const { exec, spawn }  = require('child_process');
+
+
+router.post('/ping', (req,res) => {
+// defect
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+// {/fact}
+    
+})
+
+router.post('/gzip', (req,res) => {
+    exec(
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+          console.log('err: ', err)
+          console.log('data: ', data);
+          res.send('done');
+    });
+})
+
+router.get('/run', (req,res) => {
+   let cmd = req.params.cmd;
+   runMe(cmd,res)
+});
+
+function runMe(cmd,res){
+//    return spawn(cmd);
+
+    const cmdRunning = spawn(cmd, []);
+    cmdRunning.on('close', (code) => {
+        res.send(`child process exited with code ${code}`);
+    });
+}
+
+module.exports = router

--- a/row_019_exec.js
+++ b/row_019_exec.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router()
+
+const { exec, spawn }  = require('child_process');
+
+
+router.post('/ping', (req,res) => {
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+// {fact rule=os-command-injection@v1.0 defects=1}
+    
+})
+
+router.post('/gzip', (req,res) => {
+    exec(
+// defect
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+          console.log('err: ', err)
+          console.log('data: ', data);
+          res.send('done');
+    });
+// {/fact}
+})
+
+router.get('/run', (req,res) => {
+   let cmd = req.params.cmd;
+   runMe(cmd,res)
+});
+
+function runMe(cmd,res){
+//    return spawn(cmd);
+
+    const cmdRunning = spawn(cmd, []);
+    cmdRunning.on('close', (code) => {
+        res.send(`child process exited with code ${code}`);
+    });
+}
+
+module.exports = router

--- a/row_035_exec_os_command.js
+++ b/row_035_exec_os_command.js
@@ -1,0 +1,121 @@
+
+const { exec, spawn } = require('child_process');
+
+
+router.post('/ping', (req, res) => {
+    // ruleid:generic_os_command_exec2
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+})
+
+router.post('/gzip', (req, res) => {
+    // ruleid:generic_os_command_exec2
+    exec(
+// defect
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+            res.send('done');
+        });
+// {/fact}
+})
+
+var child_process = require('child_process');
+var x = 1;
+app.get('/', function (req, res) {
+    // ruleid:generic_os_command_exec
+    child_process.exec(
+        req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec('gzip' +
+        req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec('foobar' +
+        req.query.file_path + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec(
+        req.query.file_path + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    //Do not detect this
+    child_process.exec(
+        foo + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.execSync(
+        req.query.file_path + 'rsync -avAXz --info=progress2 "/src" "/dest"',
+        { stdio: 'inherit' });
+
+    res.send('Hello World!')
+
+
+    // ruleid:generic_os_command_exec
+    var foo = req.query.ping;
+    var x;
+    child_process.exec('ping -c 2 ' + foo, function (err, data) {
+        response.end();
+    });
+})
+
+var foo = '1';
+require('child_process').exec(foo + 'info=progress2 "/src" "/dest"');
+
+
+const router = require('express').Router();
+const exe = require('child_process');
+
+router.post('/', function (req, res) {
+    // ruleid:generic_os_command_exec
+    exe.exec('ls ' + req.body.dir, function (err, data) {
+        if (!err) {
+            res.json({ message: data });
+        } else {
+            res.status(500).json({ message: err });
+        }
+    });
+});
+
+module.exports = router;
+
+
+var http = require("http");
+var url = require("url");
+var exe = require('child_process');
+http.createServer(function (request, response) {
+    // ruleid:generic_os_command_exec
+    var parsedUrl = url.parse(request.url, true);
+    exe.exec('ping -c 2 ' + parsedUrl.query.ping, function (err, data) {
+        response.end();
+    });
+
+}).listen(8888);
+


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Javascript files from the `javascript_os-command-injection-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `javascript_os-command-injection-annotated`
- Batch: javascript-os-command-injection-annotated-javascript-batch-01
- Language: Javascript
- Contains javascript files collected from the source directory

## 🔍 Changes
- Added javascript files from `javascript_os-command-injection-annotated` maintaining original directory structure
- Files organized in batch 01 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `javascript_os-command-injection-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add multiple JS files with Express routes and examples using child_process exec/spawn (incl. execSync) for OS command execution/injection test cases.
> 
> - **Added JS examples for OS command execution**:
>   - Files: `row_001_find_vuln7.js`, `row_009_exec.js`, `row_010_exec.js`, `row_019_exec.js`, `row_035_exec_os_command.js`.
> - **Express routes and handlers**:
>   - `POST /ping`: executes `req.body.url` via `exec`.
>   - `POST /gzip`: runs `gzip` on `req.query.file_path` via `exec`.
>   - `GET /run`: spawns arbitrary `cmd` via `spawn`.
> - **Additional patterns in `row_035_exec_os_command.js`**:
>   - Multiple `child_process.exec` calls on request-derived inputs and a `execSync` example.
>   - Adds an Express `POST /` executing `ls` with `req.body.dir`.
>   - Adds a basic HTTP server executing `ping` from query params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8920332c1be592384bb24a436fabe0024975ca36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->