### PR TITLE
Add Javascript Files from javascript_os-command-injection-annotated - Batch 07

### DIFF
--- a/row_005_exec.js
+++ b/row_005_exec.js
@@ -1,0 +1,81 @@
+// Use Express for serving the webpages
+const express = require("express");
+
+// To write to file
+const fs = require('fs');
+const { get } = require("http");
+
+// Running a file
+const { exec } = require('child_process');
+
+// Initialisation
+const app = express();
+const port = 3000;
+
+// Save functions and IDs in memory
+var code = {}
+
+// Use the EJS display engine
+app.set("view engine", "ejs");
+
+//body parser
+app.use(
+	express.urlencoded({
+		extended: true,
+	})
+);
+
+// Home page
+app.get("/", (req, res) => {
+	res.render("home");
+});
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+// Execute a function
+app.get('/function/:id?', function(req , res){
+		
+	var output = ""
+
+// defect
+	exec(`node ./functions/${req.params.id}`, (error, stdout, stderr) => {
+		if (error) {
+		  console.error(`exec error: ${error}`);
+		  return;
+		}
+		res.json({ output: stdout });
+// {/fact}
+	});
+	
+});
+
+// Show functions
+app.get('/functions', (req,res) => {
+	res.render("table", {functions: code});
+})
+
+// Create new function
+app.post("/post_function", (req, res) => {
+	
+	if (!req.body.code) {
+		res.status(404, "Error. No code found.")
+	}
+
+	var random_id = (Math.random() + 1).toString(36).substring(7);
+
+	fs.writeFile(`./functions/${random_id}`, req.body.code, err => {
+		if (err) {
+			res.status(404, "Error. No code found.")
+		}
+		// file written successfully
+	});
+
+	code[random_id] = req.body.code;
+
+	res.redirect('/functions')
+
+});
+
+// Start serving
+app.listen(port, () => {
+	console.log(`Example app listening on port ${port}`);
+});

--- a/row_014_exec.js
+++ b/row_014_exec.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router()
+// {fact rule=os-command-injection@v1.0 defects=1}
+
+const { exec, spawn }  = require('child_process');
+
+
+router.post('/ping', (req,res) => {
+// defect
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+// {/fact}
+    
+})
+
+router.post('/gzip', (req,res) => {
+    exec(
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+          console.log('err: ', err)
+          console.log('data: ', data);
+          res.send('done');
+    });
+})
+
+router.get('/run', (req,res) => {
+   let cmd = req.params.cmd;
+   runMe(cmd,res)
+});
+
+function runMe(cmd,res){
+//    return spawn(cmd);
+
+    const cmdRunning = spawn(cmd, []);
+    cmdRunning.on('close', (code) => {
+        res.send(`child process exited with code ${code}`);
+    });
+}
+
+module.exports = router

--- a/row_034_exec_os_command.js
+++ b/row_034_exec_os_command.js
@@ -1,0 +1,121 @@
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+const { exec, spawn } = require('child_process');
+
+
+router.post('/ping', (req, res) => {
+    // ruleid:generic_os_command_exec2
+// defect
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+// {/fact}
+
+})
+
+router.post('/gzip', (req, res) => {
+    // ruleid:generic_os_command_exec2
+    exec(
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+            res.send('done');
+        });
+})
+
+var child_process = require('child_process');
+var x = 1;
+app.get('/', function (req, res) {
+    // ruleid:generic_os_command_exec
+    child_process.exec(
+        req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec('gzip' +
+        req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec('foobar' +
+        req.query.file_path + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec(
+        req.query.file_path + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    //Do not detect this
+    child_process.exec(
+        foo + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.execSync(
+        req.query.file_path + 'rsync -avAXz --info=progress2 "/src" "/dest"',
+        { stdio: 'inherit' });
+
+    res.send('Hello World!')
+
+
+    // ruleid:generic_os_command_exec
+    var foo = req.query.ping;
+    var x;
+    child_process.exec('ping -c 2 ' + foo, function (err, data) {
+        response.end();
+    });
+})
+
+var foo = '1';
+require('child_process').exec(foo + 'info=progress2 "/src" "/dest"');
+
+
+const router = require('express').Router();
+const exe = require('child_process');
+
+router.post('/', function (req, res) {
+    // ruleid:generic_os_command_exec
+    exe.exec('ls ' + req.body.dir, function (err, data) {
+        if (!err) {
+            res.json({ message: data });
+        } else {
+            res.status(500).json({ message: err });
+        }
+    });
+});
+
+module.exports = router;
+
+
+var http = require("http");
+var url = require("url");
+var exe = require('child_process');
+http.createServer(function (request, response) {
+    // ruleid:generic_os_command_exec
+    var parsedUrl = url.parse(request.url, true);
+    exe.exec('ping -c 2 ' + parsedUrl.query.ping, function (err, data) {
+        response.end();
+    });
+
+}).listen(8888);
+

--- a/row_037_exec_os_command.js
+++ b/row_037_exec_os_command.js
@@ -1,0 +1,121 @@
+
+const { exec, spawn } = require('child_process');
+
+
+router.post('/ping', (req, res) => {
+    // ruleid:generic_os_command_exec2
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+})
+
+router.post('/gzip', (req, res) => {
+    // ruleid:generic_os_command_exec2
+    exec(
+// defect
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+            res.send('done');
+        });
+// {/fact}
+})
+
+var child_process = require('child_process');
+var x = 1;
+app.get('/', function (req, res) {
+    // ruleid:generic_os_command_exec
+    child_process.exec(
+        req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec('gzip' +
+        req.query.file_path,
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec('foobar' +
+        req.query.file_path + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.exec(
+        req.query.file_path + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    //Do not detect this
+    child_process.exec(
+        foo + "asdD",
+        function (err, data) {
+            console.log('err: ', err)
+            console.log('data: ', data);
+        });
+
+    // ruleid:generic_os_command_exec
+    child_process.execSync(
+        req.query.file_path + 'rsync -avAXz --info=progress2 "/src" "/dest"',
+        { stdio: 'inherit' });
+
+    res.send('Hello World!')
+
+
+    // ruleid:generic_os_command_exec
+    var foo = req.query.ping;
+    var x;
+    child_process.exec('ping -c 2 ' + foo, function (err, data) {
+        response.end();
+    });
+})
+
+var foo = '1';
+require('child_process').exec(foo + 'info=progress2 "/src" "/dest"');
+
+
+const router = require('express').Router();
+const exe = require('child_process');
+
+router.post('/', function (req, res) {
+    // ruleid:generic_os_command_exec
+    exe.exec('ls ' + req.body.dir, function (err, data) {
+        if (!err) {
+            res.json({ message: data });
+        } else {
+            res.status(500).json({ message: err });
+        }
+    });
+});
+
+module.exports = router;
+
+
+var http = require("http");
+var url = require("url");
+var exe = require('child_process');
+http.createServer(function (request, response) {
+    // ruleid:generic_os_command_exec
+    var parsedUrl = url.parse(request.url, true);
+    exe.exec('ping -c 2 ' + parsedUrl.query.ping, function (err, data) {
+        response.end();
+    });
+
+}).listen(8888);
+

--- a/row_040_exec.js
+++ b/row_040_exec.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const router = express.Router()
+// {fact rule=os-command-injection@v1.0 defects=1}
+
+const { exec, spawn }  = require('child_process');
+
+
+router.post('/ping', (req,res) => {
+// defect
+    exec(`${req.body.url}`, (error) => {
+        if (error) {
+            return res.send('error');
+        }
+        res.send('pong')
+    })
+// {/fact}
+})
+
+router.post('/gzip', (req,res) => {
+    exec(
+        'gzip ' + req.query.file_path,
+        function (err, data) {
+          console.log('err: ', err)
+          console.log('data: ', data);
+          res.send('done');
+    });
+})
+
+router.get('/run', (req,res) => {
+   let cmd = req.params.cmd;
+   runMe(cmd,res)
+});
+
+function runMe(cmd,res){
+//    return spawn(cmd);
+
+    const cmdRunning = spawn(cmd, []);
+    cmdRunning.on('close', (code) => {
+        res.send(`child process exited with code ${code}`);
+    });
+}
+
+module.exports = router


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Javascript files from the `javascript_os-command-injection-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `javascript_os-command-injection-annotated`
- Batch: javascript-os-command-injection-annotated-javascript-batch-07
- Language: Javascript
- Contains javascript files collected from the source directory

## 🔍 Changes
- Added javascript files from `javascript_os-command-injection-annotated` maintaining original directory structure
- Files organized in batch 07 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `javascript_os-command-injection-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multiple JS files with Express routes and examples that run shell commands using child_process with request-driven inputs.
> 
> - **New JavaScript files (Express + child_process)**:
>   - `row_005_exec.js`: Minimal Express app; renders home/table; saves uploaded code to `./functions/<id>`; executes `node ./functions/:id` via `exec`.
>   - `row_014_exec.js`, `row_040_exec.js`: Routers with endpoints:
>     - `/ping` executes command from `req.body.url`.
>     - `/gzip` runs `gzip` on `req.query.file_path`.
>     - `/run` spawns a command from request param.
>   - `row_034_exec_os_command.js`, `row_037_exec_os_command.js`: Expanded examples using `exec`, `execSync`, and `spawn` with request-provided values; includes routes, an HTTP server ping handler, and router export.
> - **Annotations**: Includes `{fact rule=os-command-injection@v1.0}` markers highlighting command execution sites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3e3230c53ba211d16a2bd11ab3c1b8e711d5a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->