### PR TITLE
Add Python Files from python_xss-annotated - Batch 01

### DIFF
--- a/row_018_render.py
+++ b/row_018_render.py
@@ -1,0 +1,58 @@
+import io
+import os
+import flask
+import requests
+from jinja2 import Template
+
+
+def _read_if_exists(url_prefix, custom_prefix, suffix, engine):
+
+    if url_prefix is None:
+        custom_file_name = custom_prefix + "." + suffix
+        if os.path.isfile(custom_file_name):
+            with io.open(custom_file_name, "r") as f:
+                return f.read()
+    else:
+        url = url_prefix + "/" + custom_prefix + "." + suffix
+        response = requests.get(url)
+        if response.status_code != 404:
+            return response.text
+
+    vendor_file_name = os.path.join(
+        os.path.dirname(__file__), "static", "engines", engine, "vendor." + suffix
+    )
+    if os.path.isfile(vendor_file_name):
+        with io.open(vendor_file_name, "r") as f:
+            return f.read()
+
+    return ""
+
+
+def render(engine, url_prefix, md_file_prefix, markdown):
+
+    engine_root = flask.url_for("static", filename="engines/" + engine)
+
+    # flask.Markup to disable autoescaping
+    custom_css = flask.Markup(
+        _read_if_exists(url_prefix, md_file_prefix, "css", engine)
+    )
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+
+    _tmp = _read_if_exists(url_prefix, md_file_prefix, "head.html", engine)
+    custom_head_html = flask.Markup(Template(_tmp).render(engine_root=engine_root))
+
+    _tmp = _read_if_exists(url_prefix, md_file_prefix, "body.html", engine)
+# defect
+    custom_body_html = flask.Markup(
+        Template(_tmp).render(markdown=markdown, engine_root=engine_root)
+    )
+
+    return flask.render_template(
+        "render.html",
+# {/fact}
+        title="presentation",
+        custom_css=custom_css,
+        custom_head_html=custom_head_html,
+        custom_body_html=custom_body_html,
+        engine=engine,
+    )

--- a/row_019_CSSI.py
+++ b/row_019_CSSI.py
@@ -1,0 +1,29 @@
+from flask import Flask, request, render_template
+import flask
+
+app = Flask(__name__, static_url_path='/static', static_folder='static')
+app.config['DEBUG'] = True
+
+
+@app.route("/")
+def start():
+
+    return render_template("index.html")
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+
+
+@app.route("/home", methods=['POST'])
+def home():
+    injection = request.form['inj_text']
+# defect
+    return render_template("index.html", injection = flask.Markup(injection))
+
+@app.errorhandler(404)
+def page_not_found(e):
+    return render_template("404.html")
+
+# {/fact}
+
+if __name__ == "__main__":
+    app.run(host='0.0.0.0')
+

--- a/row_020_app.py
+++ b/row_020_app.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sqlite3
+import subprocess
+import smtplib
+from pathlib import Path
+
+import flask
+import jsonpickle
+import requests
+
+from flask import Flask, render_template
+from lxml import etree
+from werkzeug.utils import redirect
+
+app = Flask(__name__)
+
+@app.route("/rce/<string:payload>")
+def definite_rce(payload: str) -> None:
+    subprocess.run(payload, shell=True)
+
+
+@app.route("/rce/<string:payload>")
+def potential_rce_1(payload: str) -> None:
+    subprocess.run(["echo", payload])
+
+
+@app.route("/rce/<int:payload>")
+def potential_rce_2(payload: int) -> None:
+    subprocess.run(f"echo {payload}", shell=True)
+
+
+@app.route("/pt/<string:payload>")
+def definite_pt(payload: str) -> str:
+    f = open(payload, "r")
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+    text = f.read()
+    return text
+
+@app.route("/xss/<string:payload>")
+def definite_xss(payload: str) -> None:
+# defect
+    content = flask.Markup(payload)
+    return render_template(content)
+
+
+@app.route("/sql/<string:payload>")
+def definite_sql(payload: str) -> None:
+# {/fact}
+    con = sqlite3.connect()
+    cur = con.cursor()
+    cur.execute(f"SELECT info FROM users WHERE name={payload}")
+
+
+@app.route("/ssrf/<string:payload>")
+def definite_ssrf(payload: str) -> None:
+    requests.get(payload)
+
+
+@app.route("/xxe/<string:payload>")
+def definite_xxe(payload: str) -> None:
+    etree.fromstring(payload)
+
+@app.route("/getattr_tp/<string:payload>")
+def user_data_to_getattr_tp(payload: str) -> None:
+    jsonpickle.unpickler.loadclass(payload)
+
+@app.route("/getattr_tn/<string:payload>")
+def user_data_to_getattr_tn(payload: str) -> None:
+    payload = "payload"
+    jsonpickle.unpickler.loadclass(payload)
+
+@app.route("/user_data_to_filesystem_read_write_tp/<path:payload>")
+def user_data_to_filesystem_read_write_tp(payload: Path) -> None:
+    with open(payload) as f:
+        data = f.read()
+    return data
+
+@app.route("/open_redirect_tp/<string:payload>")
+def open_redirect_tp(payload: str) -> None:
+    # TODO(T189346522): Fix false negative due to unresolved call.
+    redirect(payload)
+
+@app.route("/open_redirect_tn/<int:payload>")
+def open_redirect_tn(payload: int) -> None:
+    redirect("test", payload)
+
+@app.route("/user_controlled_data_to_email_send_to_users_tp/<string:payload>")
+def user_controlled_data_to_email_send_to_users_tp(payload: str) -> None:
+    smtp_obj = smtplib.SMTP("test", 123, "test", 3000)
+    smtp_obj.sendmail("test", "test", payload)
+
+@app.route("/user_controlled_data_to_email_send_to_users_tn/<string:payload>")
+def user_controlled_data_to_email_send_to_users_tn(payload: str) -> None:
+    payload = "test"
+    smtp_obj = smtplib.SMTP("test", 123, "test", 3000)
+    smtp_obj.sendmail("test", "test", payload)
+
+@app.route("/user_controlled_data_flows_into_url_like_string_tp/<string:payload>")
+def user_controlled_data_flows_into_url_like_string_tp(payload: str) -> None:
+    # TODO(T189346647): Fix false negative due to disabled multi-source rule
+    url = "https://test/" + payload # noqa
+
+@app.route("/user_controlled_data_flows_into_url_like_string_tn/<string:payload>")
+def user_controlled_data_flows_into_url_like_string_tn(payload: str) -> None:
+    url = "test/" + payload # noqa

--- a/row_021_app.py
+++ b/row_021_app.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sqlite3
+import subprocess
+import smtplib
+from pathlib import Path
+
+import flask
+import jsonpickle
+import requests
+
+from flask import Flask, render_template
+from lxml import etree
+from werkzeug.utils import redirect
+
+app = Flask(__name__)
+
+@app.route("/rce/<string:payload>")
+def definite_rce(payload: str) -> None:
+    subprocess.run(payload, shell=True)
+
+
+@app.route("/rce/<string:payload>")
+def potential_rce_1(payload: str) -> None:
+    subprocess.run(["echo", payload])
+
+
+@app.route("/rce/<int:payload>")
+def potential_rce_2(payload: int) -> None:
+    subprocess.run(f"echo {payload}", shell=True)
+
+
+@app.route("/pt/<string:payload>")
+def definite_pt(payload: str) -> str:
+    f = open(payload, "r")
+    text = f.read()
+    return text
+
+@app.route("/xss/<string:payload>")
+def definite_xss(payload: str) -> None:
+    content = flask.Markup(payload)
+    return render_template(content)
+
+
+@app.route("/sql/<string:payload>")
+def definite_sql(payload: str) -> None:
+    con = sqlite3.connect()
+    cur = con.cursor()
+    cur.execute(f"SELECT info FROM users WHERE name={payload}")
+
+
+@app.route("/ssrf/<string:payload>")
+def definite_ssrf(payload: str) -> None:
+    requests.get(payload)
+
+
+@app.route("/xxe/<string:payload>")
+def definite_xxe(payload: str) -> None:
+    etree.fromstring(payload)
+
+@app.route("/getattr_tp/<string:payload>")
+def user_data_to_getattr_tp(payload: str) -> None:
+    jsonpickle.unpickler.loadclass(payload)
+
+@app.route("/getattr_tn/<string:payload>")
+def user_data_to_getattr_tn(payload: str) -> None:
+    payload = "payload"
+    jsonpickle.unpickler.loadclass(payload)
+
+@app.route("/user_data_to_filesystem_read_write_tp/<path:payload>")
+def user_data_to_filesystem_read_write_tp(payload: Path) -> None:
+    with open(payload) as f:
+        data = f.read()
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+    return data
+
+@app.route("/open_redirect_tp/<string:payload>")
+def open_redirect_tp(payload: str) -> None:
+    # TODO(T189346522): Fix false negative due to unresolved call.
+# defect
+    redirect(payload)
+
+@app.route("/open_redirect_tn/<int:payload>")
+def open_redirect_tn(payload: int) -> None:
+    redirect("test", payload)
+
+# {/fact}
+@app.route("/user_controlled_data_to_email_send_to_users_tp/<string:payload>")
+def user_controlled_data_to_email_send_to_users_tp(payload: str) -> None:
+    smtp_obj = smtplib.SMTP("test", 123, "test", 3000)
+    smtp_obj.sendmail("test", "test", payload)
+
+@app.route("/user_controlled_data_to_email_send_to_users_tn/<string:payload>")
+def user_controlled_data_to_email_send_to_users_tn(payload: str) -> None:
+    payload = "test"
+    smtp_obj = smtplib.SMTP("test", 123, "test", 3000)
+    smtp_obj.sendmail("test", "test", payload)
+
+@app.route("/user_controlled_data_flows_into_url_like_string_tp/<string:payload>")
+def user_controlled_data_flows_into_url_like_string_tp(payload: str) -> None:
+    # TODO(T189346647): Fix false negative due to disabled multi-source rule
+    url = "https://test/" + payload # noqa
+
+@app.route("/user_controlled_data_flows_into_url_like_string_tn/<string:payload>")
+def user_controlled_data_flows_into_url_like_string_tn(payload: str) -> None:
+    url = "test/" + payload # noqa

--- a/row_022_app.py
+++ b/row_022_app.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sqlite3
+import subprocess
+import smtplib
+from pathlib import Path
+
+import flask
+import jsonpickle
+import requests
+
+from flask import Flask, render_template
+from lxml import etree
+from werkzeug.utils import redirect
+
+app = Flask(__name__)
+
+@app.route("/rce/<string:payload>")
+def definite_rce(payload: str) -> None:
+    subprocess.run(payload, shell=True)
+
+
+@app.route("/rce/<string:payload>")
+def potential_rce_1(payload: str) -> None:
+    subprocess.run(["echo", payload])
+
+
+@app.route("/rce/<int:payload>")
+def potential_rce_2(payload: int) -> None:
+    subprocess.run(f"echo {payload}", shell=True)
+
+
+@app.route("/pt/<string:payload>")
+def definite_pt(payload: str) -> str:
+    f = open(payload, "r")
+    text = f.read()
+    return text
+
+@app.route("/xss/<string:payload>")
+def definite_xss(payload: str) -> None:
+    content = flask.Markup(payload)
+    return render_template(content)
+
+
+@app.route("/sql/<string:payload>")
+def definite_sql(payload: str) -> None:
+    con = sqlite3.connect()
+    cur = con.cursor()
+    cur.execute(f"SELECT info FROM users WHERE name={payload}")
+
+
+@app.route("/ssrf/<string:payload>")
+def definite_ssrf(payload: str) -> None:
+    requests.get(payload)
+
+
+@app.route("/xxe/<string:payload>")
+def definite_xxe(payload: str) -> None:
+    etree.fromstring(payload)
+
+@app.route("/getattr_tp/<string:payload>")
+def user_data_to_getattr_tp(payload: str) -> None:
+    jsonpickle.unpickler.loadclass(payload)
+
+@app.route("/getattr_tn/<string:payload>")
+def user_data_to_getattr_tn(payload: str) -> None:
+    payload = "payload"
+    jsonpickle.unpickler.loadclass(payload)
+
+@app.route("/user_data_to_filesystem_read_write_tp/<path:payload>")
+def user_data_to_filesystem_read_write_tp(payload: Path) -> None:
+    with open(payload) as f:
+        data = f.read()
+    return data
+
+@app.route("/open_redirect_tp/<string:payload>")
+def open_redirect_tp(payload: str) -> None:
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+    # TODO(T189346522): Fix false negative due to unresolved call.
+    redirect(payload)
+
+@app.route("/open_redirect_tn/<int:payload>")
+def open_redirect_tn(payload: int) -> None:
+# defect
+    redirect("test", payload)
+
+@app.route("/user_controlled_data_to_email_send_to_users_tp/<string:payload>")
+def user_controlled_data_to_email_send_to_users_tp(payload: str) -> None:
+    smtp_obj = smtplib.SMTP("test", 123, "test", 3000)
+    smtp_obj.sendmail("test", "test", payload)
+# {/fact}
+
+@app.route("/user_controlled_data_to_email_send_to_users_tn/<string:payload>")
+def user_controlled_data_to_email_send_to_users_tn(payload: str) -> None:
+    payload = "test"
+    smtp_obj = smtplib.SMTP("test", 123, "test", 3000)
+    smtp_obj.sendmail("test", "test", payload)
+
+@app.route("/user_controlled_data_flows_into_url_like_string_tp/<string:payload>")
+def user_controlled_data_flows_into_url_like_string_tp(payload: str) -> None:
+    # TODO(T189346647): Fix false negative due to disabled multi-source rule
+    url = "https://test/" + payload # noqa
+
+@app.route("/user_controlled_data_flows_into_url_like_string_tn/<string:payload>")
+def user_controlled_data_flows_into_url_like_string_tn(payload: str) -> None:
+    url = "test/" + payload # noqa


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Python files from the `python_xss-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `python_xss-annotated`
- Batch: python-xss-annotated-python-batch-01
- Language: Python
- Contains python files collected from the source directory

## 🔍 Changes
- Added python files from `python_xss-annotated` maintaining original directory structure
- Files organized in batch 01 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `python_xss-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new annotated Flask modules with routes demonstrating XSS and other vulnerability sinks, plus a rendering helper for custom CSS/head/body.
> 
> - **New Flask apps/endpoints**:
>   - `row_020_app.py`, `row_021_app.py`, `row_022_app.py`:
>     - Routes showcasing sinks: `rce`, `pt` (file read), `xss` (template rendering with `flask.Markup`), `sql` (raw query), `ssrf` (HTTP GET), `xxe` (XML parse), `open_redirect`, filesystem read/write, email send, and URL-like string construction.
> - **Rendering helper**:
>   - `row_018_render.py`: Adds `render(...)` that loads optional custom `css`, `head.html`, and `body.html` (from local or URL) and renders via Jinja2 with `flask.Markup`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a175e43831a8af667f1e5b8e31ed8324bc49fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->