### PR TITLE
Add Python Files from python_xss-annotated - Batch 02

### DIFF
--- a/row_015_flatpandoc.py
+++ b/row_015_flatpandoc.py
@@ -1,0 +1,118 @@
+"""
+flask_flatpages_pandoc
+~~~~~~~~~~~~~~~~~~~~~~
+
+Flask-FlatPages-Pandoc is an HTML renderer for Flask-FlatPages that uses
+pandoc as backend.
+
+:copyright: (c) 2014 Fabian Hirschmann <fabian@hirschmann.email>
+:license: MIT, see LICENSE.txt for more details.
+
+With some changes by @apas:
+
+  - Invoke pandoc via pypandoc instead subprocess
+  - Indentation changes
+  - Support of Pandoc 2.0 by @ThoseGrapefruits
+  - Support of Python 3 by @frstp64
+
+License: MIT
+"""
+
+import pkg_resources
+import pypandoc
+
+from flask import render_template_string, Markup
+
+try:
+  __version__ = pkg_resources.require("Flask-FlatPages-Pandoc")[0]
+except pkg_resources.DistributionNotFound:
+  __version__ = "0.0-dev"
+
+class FlatPagesPandoc(object):
+  """
+  Class that, when applied to a :class:`flask.Flask` instance,
+  sets up an HTML renderer using pandoc.
+  """
+  def __init__(self, source_format, app=None, pandoc_args=[],
+   pre_render=False):
+    """
+    Initializes Flask-FlatPages-Pandoc.
+
+    :param source_format: the source file format; directly passed
+                          to pandoc.
+    :type source_format: string
+    :param app: your application. Can be omitted if you call
+                :meth:`init_app` later.
+    :type app: :class:`flask.Flask`
+    :param pandoc_args: extra arguments passed to pandoc
+    :type pandoc_args: sequence
+    :param pre_render: pre-render the page as :class:`flask.Markup`
+    :type pre_render: boolean
+    """
+    self.source_format = source_format
+    self.pandoc_args = pandoc_args
+    self.pre_render = pre_render
+
+    if app:
+      self.init_app(app)
+
+  def init_app(self, app):
+    """
+    Used to initialize an application. This is useful when passing
+    an app later.
+
+    :param app: your application
+    :type app: :class:`flask.Flask`
+    """
+    self.app = app
+
+    # The following lambda expression works around Flask-FlatPage's
+    # reflection magic.
+    self.app.config["FLATPAGES_HTML_RENDERER"] = lambda t: self.renderer(t)
+
+  def renderer(self, text):
+    """
+    Renders a flat page to HTML.
+
+    :param text: the text of the flat page
+    :type text: string
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+    """
+    #if type(text) == str:
+    #  text = str(text, self.app.config["FLATPAGES_ENCODING"])
+
+    if self.pre_render:
+# defect
+      text = render_template_string(Markup(text))
+
+    extra_args = [
+      "--filter=pandoc-crossref",
+      "--filter=pandoc-citeproc",
+      "--filter=pandoc-sidenote",
+# {/fact}
+      "--standalone",
+      "--mathml",
+      "--base-header-level=2",
+      "--highlight-style", "pygments",
+      "--bibliography=pages/all.bib",
+      "--csl=pages/lncs.csl",
+      "-Mreference-section-title=References",
+      "-Mlink-citations=true"
+    ]
+
+    pandocver = int(pypandoc.get_pandoc_version()[0])
+
+    if pandocver < 2:
+      extra_args.append("-S")
+      format_str = "markdown+raw_tex+yaml_metadata_block"
+    else:
+      format_str = "markdown+raw_tex+smart+yaml_metadata_block+header_attributes"
+
+    output = pypandoc.convert_text(
+      text.encode("utf8"),
+      'html',
+      format = format_str,
+      extra_args=extra_args
+    )
+
+    return output

--- a/row_016_render.py
+++ b/row_016_render.py
@@ -1,0 +1,58 @@
+import io
+import os
+import flask
+import requests
+from jinja2 import Template
+
+
+def _read_if_exists(url_prefix, custom_prefix, suffix, engine):
+
+    if url_prefix is None:
+        custom_file_name = custom_prefix + "." + suffix
+        if os.path.isfile(custom_file_name):
+            with io.open(custom_file_name, "r") as f:
+                return f.read()
+    else:
+        url = url_prefix + "/" + custom_prefix + "." + suffix
+        response = requests.get(url)
+        if response.status_code != 404:
+            return response.text
+
+    vendor_file_name = os.path.join(
+        os.path.dirname(__file__), "static", "engines", engine, "vendor." + suffix
+    )
+    if os.path.isfile(vendor_file_name):
+        with io.open(vendor_file_name, "r") as f:
+            return f.read()
+
+    return ""
+
+
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+def render(engine, url_prefix, md_file_prefix, markdown):
+
+    engine_root = flask.url_for("static", filename="engines/" + engine)
+
+    # flask.Markup to disable autoescaping
+# defect
+    custom_css = flask.Markup(
+        _read_if_exists(url_prefix, md_file_prefix, "css", engine)
+    )
+
+    _tmp = _read_if_exists(url_prefix, md_file_prefix, "head.html", engine)
+    custom_head_html = flask.Markup(Template(_tmp).render(engine_root=engine_root))
+# {/fact}
+
+    _tmp = _read_if_exists(url_prefix, md_file_prefix, "body.html", engine)
+    custom_body_html = flask.Markup(
+        Template(_tmp).render(markdown=markdown, engine_root=engine_root)
+    )
+
+    return flask.render_template(
+        "render.html",
+        title="presentation",
+        custom_css=custom_css,
+        custom_head_html=custom_head_html,
+        custom_body_html=custom_body_html,
+        engine=engine,
+    )

--- a/row_017_render.py
+++ b/row_017_render.py
@@ -1,0 +1,58 @@
+import io
+import os
+import flask
+import requests
+from jinja2 import Template
+
+
+def _read_if_exists(url_prefix, custom_prefix, suffix, engine):
+
+    if url_prefix is None:
+        custom_file_name = custom_prefix + "." + suffix
+        if os.path.isfile(custom_file_name):
+            with io.open(custom_file_name, "r") as f:
+                return f.read()
+    else:
+        url = url_prefix + "/" + custom_prefix + "." + suffix
+        response = requests.get(url)
+        if response.status_code != 404:
+            return response.text
+
+    vendor_file_name = os.path.join(
+        os.path.dirname(__file__), "static", "engines", engine, "vendor." + suffix
+    )
+    if os.path.isfile(vendor_file_name):
+        with io.open(vendor_file_name, "r") as f:
+            return f.read()
+
+    return ""
+
+
+def render(engine, url_prefix, md_file_prefix, markdown):
+
+    engine_root = flask.url_for("static", filename="engines/" + engine)
+
+    # flask.Markup to disable autoescaping
+# {fact rule=cross-site-scripting@v1.0 defects=1}
+    custom_css = flask.Markup(
+        _read_if_exists(url_prefix, md_file_prefix, "css", engine)
+    )
+
+    _tmp = _read_if_exists(url_prefix, md_file_prefix, "head.html", engine)
+# defect
+    custom_head_html = flask.Markup(Template(_tmp).render(engine_root=engine_root))
+
+    _tmp = _read_if_exists(url_prefix, md_file_prefix, "body.html", engine)
+    custom_body_html = flask.Markup(
+        Template(_tmp).render(markdown=markdown, engine_root=engine_root)
+    )
+# {/fact}
+
+    return flask.render_template(
+        "render.html",
+        title="presentation",
+        custom_css=custom_css,
+        custom_head_html=custom_head_html,
+        custom_body_html=custom_body_html,
+        engine=engine,
+    )


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Python files from the `python_xss-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `python_xss-annotated`
- Batch: python-xss-annotated-python-batch-02
- Language: Python
- Contains python files collected from the source directory

## 🔍 Changes
- Added python files from `python_xss-annotated` maintaining original directory structure
- Files organized in batch 02 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `python_xss-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a Pandoc-powered HTML renderer for Flask-FlatPages and helper render modules that assemble pages from local/remote assets.
> 
> - **Rendering**:
>   - **Pandoc HTML renderer** (`row_015_flatpandoc.py`): Adds `FlatPagesPandoc` using `pypandoc` to convert Markdown to HTML, configurable via `pandoc_args`, `pre_render`, and Flask app integration.
>   - **Flask render helpers** (`row_016_render.py`, `row_017_render.py`): Add `render` workflow and `_read_if_exists` to load CSS/head/body from filesystem or HTTP, render with Jinja `Template`, and return `render.html` with assembled content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a45d7c1b17226a467f89664e4b5986b838ddc39f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->