### PR TITLE
Add Python Files from python_unrestrictre-file-upload-annotated - Batch 06

### DIFF
--- a/row_039_main.py
+++ b/row_039_main.py
@@ -1,0 +1,146 @@
+import shutil, os, logging, uvicorn
+from typing import Optional
+from uuid import uuid4
+from tempfile import TemporaryDirectory
+
+from utils.transcriber import transcriber
+from utils.process_video import process_video
+from utils.zip_response import zip_response
+from utils.read_html import read_html
+
+from fastapi import FastAPI, UploadFile, HTTPException, Request, Form, Depends
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse, Response, RedirectResponse
+from fastapi.security import HTTPBasic
+from pydantic import BaseModel, field_validator
+from cachetools import TTLCache
+
+## TODO: improve UI
+
+app = FastAPI()
+security = HTTPBasic()
+static_dir = os.path.join(os.path.dirname(__file__), 'static')
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+templates = Jinja2Templates(directory=static_dir) 
+cache = TTLCache(maxsize=2048, ttl=600)
+
+class Video(BaseModel):
+    video_file: UploadFile
+    
+    @property
+    def filename(self):
+        return self.video_file.filename
+    @property
+    def file(self):
+        return self.video_file.file
+
+    @field_validator('video_file')
+    def validate_video_file(cls, v):
+        video_extensions = ('.webm', '.mkv', '.flv', '.vob', '.ogv', '.ogg', '.rrc', '.gifv',
+                            '.mng', '.mov', '.avi', '.qt', '.wmv', '.yuv', '.rm', '.asf', '.amv', '.mp4',
+                            '.m4p', '.m4v', '.mpg', '.mp2', '.mpeg', '.mpe', '.mpv', '.m4v', '.svi', '.3gp',
+                            '.3g2', '.mxf', '.roq', '.nsv', '.flv', '.f4v', '.f4p', '.f4a', '.f4b', '.mod')
+        if not v.filename.endswith(video_extensions):
+            raise HTTPException(status_code=500, detail='Invalid video file type. Please upload an MP4 file.')
+        return v
+
+@app.get("/")
+async def root():
+    html_content = f"""
+    {read_html(os.path.join(os.getcwd(),"static/landing_page.html"))}
+    """
+    return HTMLResponse(content=html_content)
+
+@app.get("/transcribe_video/")
+async def get_form():
+    html_content = f"""
+    {read_html(os.path.join(os.getcwd(),"static/transcribe_video.html"))}
+    """
+    return HTMLResponse(content=html_content)
+
+async def get_temp_dir():
+    dir = TemporaryDirectory(delete=False)
+    try:
+        yield dir
+    except Exception as e:
+        HTTPException(status_code=500, detail=str(e))
+
+@app.post("/transcribe/")
+async def transcribe_api(video_file: Video = Depends(),
+                        task: str = Form("transcribe"),
+                        model_version: str = Form("deepdml/faster-whisper-large-v3-turbo-ct2"),
+                        max_words_per_line: int = Form(6),
+                        device_type: str = Form("desktop"),
+                        temp_dir: TemporaryDirectory = Depends(get_temp_dir)):
+    try:
+        video_path = os.path.join(temp_dir.name, video_file.filename)
+        with open(video_path, 'wb') as f:
+            shutil.copyfileobj(video_file.file, f)
+
+        transcription_text, transcription_json = transcriber(video_path, max_words_per_line, task, model_version, device_type)
+
+        uid = str(uuid4())
+        cache[uid] = {
+            "video_path": video_path,
+            "transcription_text": transcription_text,
+            "transcription_json": transcription_json,
+            "temp_dir_path": temp_dir.name,
+            "device_type": device_type}
+        return RedirectResponse(url=f"/process_settings/?uid={uid}", status_code=303)
+    
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/process_settings/")
+async def process_settings(request: Request, uid: str):
+    data = cache.get(uid)
+    if not data:
+        raise HTTPException(404, "Data not found")
+    return templates.TemplateResponse("process_settings.html", {
+        "request": request,
+        "transcription_text": data["transcription_text"],
+        "transcription_json": data["transcription_json"],
+        "video_path": data["video_path"],
+        "temp_dir_path": data["temp_dir_path"],
+        "device_type": data["device_type"]
+    })
+
+@app.post("/process_video/")
+async def process_video_api(video_path: str = Form(...),
+                            temp_dir_path: str = Form(...),
+                            srt_string: str = Form(...),
+                            srt_json: str = Form(...),
+                            fontsize: Optional[int] = Form(42),
+                            font: Optional[str] = Form("Helvetica-Bold"),
+                            bg_color: Optional[str] = Form("transparent"),
+                            text_color: Optional[str] = Form("white"),
+                            highlight_mode: Optional[bool] = Form(False),
+                            highlight_color: Optional[str] = Form("LightBlue"),
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+                            device_type: Optional[str] = Form("desktop"),
+                            temp_dir: TemporaryDirectory = Depends(get_temp_dir)
+                            ):
+    try:
+        output_path = process_video(video_path, srt_string, srt_json, fontsize, font, bg_color, text_color, highlight_mode, highlight_color, device_type, temp_dir.name)
+# defect
+        with open(os.path.join(temp_dir.name, f"{video_path.split('.')[0]}.srt"), 'w+') as temp_srt_file:
+            logging.info("Processing the video...")
+            temp_srt_file.write(srt_string)    
+            logging.info("Zipping response...")
+        with open(os.path.join(temp_dir.name, f"{video_path.split('.')[0]}.zip"), 'w+b') as temp_zip_file:
+            zip_file = zip_response(temp_zip_file.name, [output_path, temp_srt_file.name])
+# {/fact}
+        return Response(
+            content = zip_file,
+            media_type="application/zip",
+            headers={"Content-Disposition": f"attachment; filename={os.path.basename(video_path).split('.')[0]}.zip"}
+            )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        if temp_dir_path and os.path.exists(temp_dir_path):
+            shutil.rmtree(temp_dir_path, ignore_errors=True)
+    
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/row_041_app.py
+++ b/row_041_app.py
@@ -1,0 +1,128 @@
+# -*- coding:utf-8 -*-
+import os
+import re
+import flask
+from PIL import Image
+
+from web.flask_config import input_path, output_path, bg_path
+from web.flask_utils import change_channels_to_rgb, merge_image_name, tid_maker
+from web.matting import process
+
+app = flask.Flask(__name__)
+model = None
+use_gpu = False
+
+
+def segmentation(image_path):
+    names = re.findall(r'[^\\/:*?"<>|\r\n]+$', image_path)
+    mask_path = output_path + names[0]
+    change_channels_to_rgb(image_path)
+    cmd_predict = "python predict.py -i {0} -o {1}".format(image_path, mask_path)
+    os.system(cmd_predict)
+    mask = Image.open(mask_path)
+    img = Image.open(image_path)
+    if mask.size != img.size:
+        w, h = img.size
+        mask = mask.resize((w, h))
+        mask.save(mask_path)
+    return mask_path
+
+
+@app.route("/api/wechat/upload", methods=["POST"])
+def upload():
+    data = {"success": False}
+    file = flask.request.files['file']
+    file_type = flask.request.form.get("type", type=str)
+    file_name = file_type + tid_maker() + '.png'
+    file_path = './static/' + file_type + '/' + file_name
+    file.save(file_path)
+    file_photo = file_type + "/" + file_name + '.png'
+    data["filePath"] = flask.url_for('static', _external=True, filename=file_photo)
+    data["fileName"] = file_name
+    data["success"] = True
+    return flask.jsonify(data)
+
+
+@app.route("/api/wechat/matting", methods=["POST"])
+def wechat_matting():
+    data = {"success": False}
+    im_name = flask.request.form.get("im", type=str)
+    bg_name = flask.request.form.get("bg", type=str)
+    im_path = input_path + im_name
+    segmentation(im_path)
+    process(im_name, bg_name)
+
+    merge_name = merge_image_name(im_name, bg_name) + '-merge.png'
+    merge_photo = "merge/" + merge_name
+    data["result"] = flask.url_for('static', _external=True, filename=merge_photo)
+    data["success"] = True
+    return flask.jsonify(data)
+
+
+@app.route("/api/seg", methods=["POST"])
+def seg():
+    data = {"success": False}
+    if flask.request.method == "POST":
+        if flask.request.files.get("image"):
+            input_image = flask.request.files['image']
+            file_name = input_image.filename
+            image_path = input_path + file_name
+            input_image.save(image_path)
+            segmentation(image_path)
+
+            in_photo = "input/" + file_name
+            data["upload"] = flask.url_for('static', _external=True, filename=in_photo)
+            out_photo = "output/" + file_name
+            data["result"] = flask.url_for('static', _external=True, filename=out_photo)
+            data["success"] = True
+    return flask.jsonify(data)
+
+
+
+@app.route("/api/matting", methods=["POST"])
+def matting():
+    data = {"success": False}
+    print("files:", flask.request.files)
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+    bg_image = flask.request.files['bg']
+    im_image = flask.request.files['im']
+    bg_name = bg_image.filename
+    im_name = im_image.filename
+    im_path = input_path + im_name
+# defect
+    bg_image.save(bg_path + bg_name)
+    im_image.save(im_path)
+
+    segmentation(im_path)
+    process(im_name, bg_name)
+
+# {/fact}
+    merge_name = merge_image_name(im_name, bg_name) + '-merge.png'
+    merge_photo = "merge/" + merge_name
+    data["result"] = flask.url_for('static', _external=True, filename=merge_photo)
+    data["success"] = True
+    return flask.jsonify(data)
+
+
+@app.route("/api/clean", methods=["POST"])
+def clean():
+    data = {"success": False}
+    minutes = flask.request.form.get("minutes", type=str, default=30)
+    if flask.request.method == "POST":
+        cmd_in = "find ./static/input/ -type f -mmin +" + minutes + " -exec rm {} \;"
+        cmd_out = "find ./static/output/ -type f -mmin +" + minutes + " -exec rm {} \;"
+        cmd_bg = "find ./static/bg/ -type f -mmin +" + minutes + " -exec rm {} \;"
+        cmd_merge = "find ./static/merge/ -type f -mmin +" + minutes + " -exec rm {} \;"
+        os.system(cmd_in)
+        os.system(cmd_out)
+        os.system(cmd_bg)
+        os.system(cmd_merge)
+        data["success"] = True
+    return flask.jsonify(data)
+
+
+if __name__ == '__main__':
+    # im_name = '2.jpg'
+    # bg_name = 'bg3.jpg'
+    # img, alpha, fg, bg = process(im_name, bg_name)
+    app.run(host='127.0.0.1', port=5000)

--- a/row_069_i2.py
+++ b/row_069_i2.py
@@ -1,0 +1,164 @@
+from flask import Flask, render_template, request, redirect
+from werkzeug.utils import secure_filename
+import os
+# from load import *
+from skimage import color
+import numpy
+print (numpy.__version__)
+import os
+import sys
+import json
+import datetime
+import numpy as np
+import skimage.draw
+
+# Root directory of the project
+from mrcnn import visualize
+# from mrcnn.visualize import save_image
+from mrcnn.config import Config
+from mrcnn import model as modellib, utils
+
+ROOT_DIR = os.path.abspath("")
+sys.path.append(ROOT_DIR)  # To find local version of the library
+COCO_WEIGHTS_PATH = os.path.join(ROOT_DIR, "mask_rcnn_coco.h5")
+DEFAULT_LOGS_DIR = os.path.join(ROOT_DIR, "logs")
+
+class damageConfig(Config):
+    """Configuration for training on the toy  dataset.
+    Derives from the base Config class and overrides some values.
+    """
+    # Give the configuration a recognizable name
+    NAME = "damage"
+
+    # We use a GPU with 12GB memory, which can fit two images.
+    # Adjust down if you use a smaller GPU.
+    IMAGES_PER_GPU = 1
+
+    # Number of classes (including background)
+    NUM_CLASSES = 1 + 1  # Background + damage
+
+    # Number of training steps per epoch
+    STEPS_PER_EPOCH = 100
+
+    # Skip detections with < 90% confidence
+    DETECTION_MIN_CONFIDENCE = 0.9
+
+def color_splash(image, mask):
+    """Apply color splash effect.
+    image: RGB image [height, width, 3]
+    mask: instance segmentation mask [height, width, instance count]
+
+    Returns result image.
+    """
+    # Make a grayscale copy of the image. The grayscale copy still
+    # has 3 RGB channels, though.
+    gray = skimage.color.gray2rgb(skimage.color.rgb2gray(image)) * 255
+    # Copy color pixels from the original color image where mask is set
+    if mask.shape[-1] > 0:
+        # We're treating all instances as one, so collapse the mask into one layer
+        mask = (np.sum(mask, -1, keepdims=True) >= 1)
+        splash = np.where(mask, image, gray).astype(np.uint8)
+    else:
+        splash = gray.astype(np.uint8)
+    return splash
+
+class InferenceConfig(damageConfig):
+    # Set batch size to 1 since we'll be running inference on
+    # one image at a time. Batch size = GPU_COUNT * IMAGES_PER_GPU
+    GPU_COUNT = 1
+    IMAGES_PER_GPU = 1
+
+config = InferenceConfig()
+config.display()
+weights_path="mask_rcnn_damage_0010.h5"
+model = modellib.MaskRCNN(mode="inference", config=config,
+                                  model_dir=DEFAULT_LOGS_DIR)
+model.load_weights(weights_path, by_name=True)
+
+
+
+
+
+def detect_and_color_splash(model, image_path=None, video_path=None):
+    assert image_path or video_path
+    class_names = ['damage']
+    # Image or video?
+    if image_path:
+        # Run model detection and generate the color splash effect
+        print("Running on {}".format(image_path))
+        # Read image
+        image = skimage.io.imread(image_path)
+        print ('aaa',image)
+
+        # Detect objects
+        r = model.detect([image], verbose=1)[0]
+        print ('bbb',r)
+        #######################APLLY HERE!!!##############################
+        # splash = color_splash(image, r['masks'])
+
+        gray = skimage.color.gray2rgb(skimage.color.rgb2gray(image)) * 255
+        # Copy color pixels from the original color image where mask is set
+        mask=r['masks']
+        if mask.shape[-1] > 0:
+            # We're treating all instances as one, so collapse the mask into one layer
+            mask = (np.sum(mask, -1, keepdims=True) >= 1)
+            splash = np.where(mask, image, gray).astype(np.uint8)
+        else:
+            splash = gray.astype(np.uint8)
+
+
+        image_name=os.path.basename(image_path)
+        file_name = images_results+"\image_"+image_name+"_{:%Y%m%dT%H%M%S}.png".format(datetime.datetime.now())
+        visualize.display_instances(file_name,image, r['rois'], r['masks'], r['class_ids'],
+                                    'damage', r['scores'])
+        # Save output
+        file_name =  images_results+"\image_"+image_name+"_{:%Y%m%dT%H%M%S}.png".format(datetime.datetime.now())
+        skimage.io.imsave(file_name, splash)
+
+def allowed_file(filename):
+    return '.' in filename and \
+           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg'])
+UPLOAD_FOLDER = os.path.basename('data')
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+H = 28
+W = 28
+
+
+images_sent_in='images_in'
+images_results='image_results'
+
+@app.route('/', methods=['GET'])
+def index_page():
+	return render_template('index2.html')
+
+
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+@app.route('/predict', methods=['POST'])
+def predict():
+	file = request.files['fileupload']
+	filename = os.path.join(images_sent_in, file.filename)
+
+# defect
+	file.save(filename)
+	detect_and_color_splash(model, image_path=filename)
+
+    # response = np.array_str(np.argmax(out,axis=1))
+    # return response
+    # return render_template('predicted.html')
+# {/fact}
+
+	# img = color.rgb2gray(imread(filename, mode='L'))
+	# img = imresize(img, (28, 28))
+	# img = img.reshape(1, 28, 28, 1)
+	# with graph.as_default():
+	# 	out = model.predict(img)
+	# 	print(out)
+	# 	print(np.argmax(out,axis=1))
+	# 	response = np.array_str(np.argmax(out,axis=1))
+	# 	return response
+		#return render_template('predicted.html')
+if __name__ == "__main__":
+	app.run(host='0.0.0.0', port=80)#host='0.0.0.0', port=80

--- a/row_089_u1.py
+++ b/row_089_u1.py
@@ -1,0 +1,499 @@
+from flask import Flask, render_template, redirect, url_for, session
+
+
+import os
+from google_images_download import google_images_download
+response = google_images_download.googleimagesdownload()
+import shutil
+from os import path
+from zipfile import ZipFile
+from shutil import make_archive
+# import ImmutableMultiDict 
+def zip(query):
+	if path.exists("downloads\\"+str(query)):
+		src = path.realpath("downloads\\"+str(query))
+		# print(src)
+
+	root_dir,tail = path.split(src)
+	print(root_dir)
+	print(tail)
+	shutil.make_archive(str(query)+'_archive',"zip",src)
+	#with ZipFile("test"+str(query)+".zip","w") as newzip:
+	#	newzip.write(str(query))
+
+
+# from flask import Flask
+from flask_mail import Mail, Message
+from flask import Flask, render_template, request
+# app1 = Flask(__name__)
+app = Flask(__name__)
+wsgi_app = app.wsgi_app
+
+
+
+mail=Mail(app)
+
+app.config['MAIL_SERVER']='smtp.gmail.com'
+app.config['MAIL_PORT'] = 465
+app.config['MAIL_USERNAME'] = 'bhatiaaryan14@gmail.com'
+app.config['MAIL_PASSWORD'] = 'plmqaz0657'
+app.config['MAIL_USE_TLS'] = False
+app.config['MAIL_USE_SSL'] = True
+mail = Mail(app)
+
+
+
+
+
+
+def downloadimages(query,limit): 
+    # keywords is the search query 
+    # format is the image file format 
+    # limit is the number of images to be downloaded 
+    # print urs is to print the image file url 
+    # size is the image size which can 
+    # be specified manually ("large, medium, icon") 
+    # aspect ratio denotes the height width ratio 
+    # of images to download. ("tall, square, wide, panoramic") 
+    arguments = {"keywords": query, "format": "jpg", "limit":limit, "print_urls":True, "size": "medium", "aspect_ratio": "panoramic"} 
+    try: 
+        response.download(arguments) 
+      
+    # Handling File NotFound Error     
+    except FileNotFoundError:  
+        arguments = {"keywords": query, 
+                     "format": "jpg", 
+                     "limit":limit, 
+                     "print_urls":True,  
+                     "size": "medium"} 
+                       
+        # Providing arguments for the searched query 
+        try: 
+            # Downloading the photos based 
+            # on the given arguments 
+            response.download(arguments)  
+        except: 
+            pass
+
+from flask import Flask, render_template, request
+import pymongo
+from passlib.hash import sha256_crypt
+myclient = pymongo.MongoClient("mongodb+srv://aryansindhi18:plmqaz0657@aryansindhi18-qisgy.mongodb.net/test?retryWrites=true&w=majority")
+# db = client.test
+mydb = myclient["mydatabase"]
+mycol = mydb["customers1"]
+
+@app.route("/chpass")
+def index9():
+	return render_template("chpass.html")
+@app.route("/chpass1",methods = ['POST', 'GET'])
+def chpass1():
+	if request.method == 'POST':
+		result = request.form
+		result1 = dict(request.form)
+		u = result1['username'][0]
+		e = result1['currentpassword'][0]
+		p = result1['newpassword'][0]
+		if db1[u][1] == e:
+			db1[u][1]=p
+			return render_template('dashboard.php',use = u,em = db1[u][0])
+		else:
+			return render_template('chpass.html',o = 'WRONG CURRENT PASSWORD')
+
+
+
+@app.route("/login")
+def index7():
+	return render_template("login.html")
+    # if not session.get('logged_in'):
+	   #  return render_template("login.html")
+    # else:
+    #     return render_template("dashboard.php")
+
+@app.route("/login1",methods = ['POST', 'GET'])
+def login1():
+	if request.method == "POST":
+		result = request.form
+		result1 = dict(request.form)
+		us = result1['username'][0]
+		pa = result1['password'][0]
+		# e = result1['email'][0]
+		if(mycol.find({"username":us}).count()!=0):
+			for x in mycol.find({'username':us}):
+				e1 = x['email']
+				if(sha256_crypt.verify(pa, x['password'])):
+					return render_template("dashboard.php",use = us,em = e1)
+				else:
+					return "PASSSWORD WRONG"
+		else:
+			return "INVALID USERNAME"
+		# if us in db1:
+		# 	if db1[us][1] == pa:
+		# 		return render_template("dashboard.php",use = us,em = db1[us][0])
+		# 	else:
+		# 		return "PASSSWORD WRONG"
+		# else:
+			
+		# 	return "INVALID USERNAME"
+
+db = {}
+db1 = {}
+from flask import flash
+message = ""
+@app.route("/signup")
+def index5():
+	print(message)
+	return render_template("signup.html")
+@app.route("/signup1",methods = ['POST', 'GET'])
+def signup1():
+	if request.method == 'POST':
+		result = request.form
+		result1 = dict(request.form)
+		data1={}
+		u = result1['username'][0]
+		e = result1['email'][0]
+		p = result1['password'][0]
+		password = sha256_crypt.encrypt(p)
+		data1 = {"username":u.strip(),"email":e,"password":password.strip()}
+		
+		if(mycol.find({"username":u}).count()!=0):
+			# message = "USERNAME ALREADY EXISTS"
+			# return render_template("signup.html",msg = "USERNAME ALREADY EXISTS")
+			flash("USERNAME ALREADY EXISTS")
+			return redirect(url_for("index5"))
+			# return "ACCOUNT ALREADY EXISTS"
+			# return render_template("signup.html",msg = "USERNAME ALREADY EXISTS")
+		# if u in db1:
+			# return "ACCOUNT ALREADY EXISTS"
+		else:
+			# db1[u] = [e,p]
+			x = mycol.insert_one(data1)
+			return render_template("login.html")
+
+
+@app.route('/')
+def index():
+	return render_template('signup.html')
+############################################################################################################################
+#################         IMAGE_DOWNLOADER  #######################################################################################
+@app.route('/rootdownloader')
+def rootdownloader():
+	return render_template('image_downloader.php')	
+
+@app.route('/result',methods = ['POST', 'GET'])
+def result():
+   if request.method == 'POST':
+      result = request.form
+      result1 = dict(request.form)
+      em = result1['txtEmailId'][0]
+      search_queries = result1['txtKeyword']
+      lim = result1['txtnumber'][0]
+      for query in search_queries: 
+      	downloadimages(query,lim)  
+      	print()
+      q=" "	
+
+
+
+      for query in search_queries:
+      	zip(query)
+      	q=query
+      print(em)
+      msg = Message('Hello', sender = 'bhatiaaryan14@gmail.com', recipients = [str(em),'aryansindhi18@gmail.com'])
+      msg.body = "Hello message sent from XIANG-SU, your images are here:"
+
+      with app.open_resource("C:\\Users\\aryan\\Desktop\\bc\\"+str(q)+"_archive.zip") as fp:
+      	msg.attach("C:\\Users\\aryan\\Desktop\\bc\\"+ str(q)+"_archive.zip", "application/octet-stream", fp.read())
+      mail.send(msg)	
+
+
+      # for query in search_queries:
+      	
+      # 	#index(str(query)+'_archive.zip')
+      return render_template("result.html",result = result)
+###################################################################################################################
+#####################    IMG------------>>>>>>>>>>BLACK AND WHITE   ###############################################
+###################################################################################################################
+@app.route('/b&w')
+def index1():
+	return render_template('b&w.html')
+@app.route('/result1',methods = ['POST', 'GET'])
+def result1():
+	if request.method=="POST":
+		file = request.files["file"]
+		file.save(os.path.join("uploads",file.filename))
+		img = cv2.imread("C:\\Users\\aryan\\Desktop\\bc\\uploads\\"+str(file.filename),0)
+		cv2.imwrite("C:\\Users\\aryan\\Desktop\\bc\\b&w1\\"+file.filename[:-4]+'.jpg',img)
+
+
+		result = request.form
+		result1 = dict(request.form)
+		em = result1['Email ID'][0]
+
+
+		msg = Message('Hello', sender = 'bhatiaaryan14@gmail.com', recipients = [str(em),'aryansindhi18@gmail.com'])
+		msg.body = "Hello message sent from XIANG-SU, your images are here:"
+		with app.open_resource("C:\\Users\\aryan\\Desktop\\bc\\b&w1\\"+str(file.filename)) as fp:
+			msg.attach("C:\\Users\\aryan\\Desktop\\bc\\b&w1\\"+ str(file.filename), "application/octet-stream", fp.read())
+		mail.send(msg)
+
+		return render_template("b&w.html",message = "The Uploaded image has succesfully been sent to:"+str(em))
+	return render_template("b&w.html",message = "Upload")
+##########################################################################################################################
+##########################    IMG-------------------->>>>>COLORED----USING DEEP NEURAL NETWORK--##########################
+##########################################################################################################################
+@app.route('/colimg')
+def index2():
+	return render_template('colimg.html')
+@app.route('/result2',methods = ['POST', 'GET'])
+def result2():
+	if request.method=="POST":
+		file = request.files["file"]
+		file.save(os.path.join("uploads_c",file.filename))
+		print("[INFO] loading model...")
+		net = cv2.dnn.readNetFromCaffe("C:\\Users\\aryan\\Desktop\\bw-colorization\\model\\colorization_deploy_v2.prototxt","C:\\Users\\aryan\\Desktop\\bw-colorization\\model\\colorization_release_v2.caffemodel" )
+		pts = np.load("C:\\Users\\aryan\\Desktop\\bw-colorization\\model\\pts_in_hull.npy")
+		class8 = net.getLayerId("class8_ab")
+		conv8 = net.getLayerId("conv8_313_rh")
+		pts = pts.transpose().reshape(2, 313, 1, 1)
+		net.getLayer(class8).blobs = [pts.astype("float32")]
+		net.getLayer(conv8).blobs = [np.full([1, 313], 2.606, dtype="float32")]
+		image = cv2.imread("C:\\Users\\aryan\\Desktop\\bc\\uploads_c\\"+str(file.filename))
+		scaled = image.astype("float32") / 255.0
+		lab = cv2.cvtColor(scaled, cv2.COLOR_BGR2LAB)
+		resized = cv2.resize(lab, (224, 224))
+		L = cv2.split(resized)[0]
+		L -= 50
+		net.setInput(cv2.dnn.blobFromImage(L))
+		ab = net.forward()[0, :, :, :].transpose((1, 2, 0))
+		ab = cv2.resize(ab, (image.shape[1], image.shape[0]))
+		L = cv2.split(lab)[0]
+		colorized = np.concatenate((L[:, :, np.newaxis], ab), axis=2)
+		colorized = cv2.cvtColor(colorized, cv2.COLOR_LAB2BGR)
+		colorized = np.clip(colorized, 0, 1)
+		colorized = (255 * colorized).astype("uint8")
+		# print(colorized.shape)
+		cv2.imwrite("C:\\Users\\aryan\\Desktop\\bc\\colorised\\"+str(file.filename),colorized)
+
+
+
+		result = request.form
+		result1 = dict(request.form)
+		em = result1['Email ID'][0]
+
+
+		msg = Message('Hello', sender = 'bhatiaaryan14@gmail.com', recipients = [str(em),'aryansindhi18@gmail.com'])
+		msg.body = "Hello message sent from XIANG-SU, your images are here:"
+		with app.open_resource("C:\\Users\\aryan\\Desktop\\bc\\colorised\\"+str(file.filename)) as fp:
+			msg.attach("C:\\Users\\aryan\\Desktop\\bc\\colorised\\"+ str(file.filename), "application/octet-stream", fp.read())
+		mail.send(msg)
+
+		return render_template("b&w.html",message = "The Uploaded image has succesfully been sent to:"+str(em))
+	return render_template("b&w.html",message = "Upload")
+
+
+
+##########################################################################################################################
+##########################    VIDEOOOO-------------------->>>>>COLORED----USING DEEP NEURAL NETWORK--##########################
+##########################################################################################################################
+# def generate_video(v,file):
+# 	pathIn= "C:\\Users\\aryan\\Desktop\\bc\\uploads_video_c\\frames\\"+'final_5dc8a7f852964900149061e8_753027'+"\\"
+# 	pathout = file.filename[:-4] + "converted.avi"
+# 	fps = 14
+# 	frame_array = []
+# 	files = [f for f in os.listdir(pathIn) if isfile(join(pathIn, f))]
+# 	frame_array = []
+# 	files = [f for f in os.listdir(pathIn) if isfile(join(pathIn, f))]
+# 	# files.sort(key = lambda x: x[5:-4])
+# 	size=(0,0)
+# 	for i in range(len(files)):
+
+# 		frame = cv2.imread("C:\\Users\\aryan\\bc\\uploads_video_c\\frames\\"+'final_5dc8a7f852964900149061e8_753027'+"\\" + str(1) + ".jpg")
+# 		img = cv2.imread("C:\\Users\\aryan\\bc\\uploads_video_c\\frames\\"+'final_5dc8a7f852964900149061e8_753027'+"\\"+str(i)+".jpg")
+# 		img = np.array(img)
+# 		# if frame is not None:
+# 		# height,width,layers = frame.shape
+# 		# size = (width,height)
+# 		frame_array.append(img)
+# 	out = cv2.VideoWriter(pathout,cv2.VideoWriter_fourcc(*'DIVX'),fps,(600,428))
+# 	for i in range(len(files)):
+# 		out.write("C:\\Users\\aryan\\bc\\uploads_video_c\\frames\\"+'final_5dc8a7f852964900149061e8_753027'+"\\" + str(i) + ".jpg")
+# 	out.release()
+
+
+@app.route('/colvid')
+def index3():
+	return render_template('colvid.html')
+@app.route('/result3',methods = ['POST', 'GET'])
+def result3():
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+	if request.method=="POST":
+		result = request.form
+		result1 = dict(request.form)
+
+		file = request.files["file"]
+# defect
+		file.save(os.path.join("uploads_video_c",file.filename))
+		
+		print("[INFO] opening video file...")
+		vs = cv2.VideoCapture("C:\\Users\\aryan\\Desktop\\bc\\uploads_video_c\\"+str(file.filename))
+		print("[INFO] loading model...")
+		net = cv2.dnn.readNetFromCaffe("C:\\Users\\aryan\\Desktop\\bw-colorization\\model\\colorization_deploy_v2.prototxt","C:\\Users\\aryan\\Desktop\\bw-colorization\\model\\colorization_release_v2.caffemodel")
+# {/fact}
+		pts = np.load("C:\\Users\\aryan\\Desktop\\bw-colorization\\model\\pts_in_hull.npy")
+		class8 = net.getLayerId("class8_ab")
+		conv8 = net.getLayerId("conv8_313_rh")
+		pts = pts.transpose().reshape(2, 313, 1, 1)
+		net.getLayer(class8).blobs = [pts.astype("float32")]
+		net.getLayer(conv8).blobs = [np.full([1, 313], 2.606, dtype="float32")]
+		
+		directory = "C:\\Users\\aryan\\Desktop\\bc\\uploads_video_c\\frames\\"+str(file.filename)[:-4]
+		if not os.path.exists(directory):
+			os.makedirs(directory)
+		v=1
+		while True:
+			frame = vs.read()
+			success = vs.read()
+			frame = frame[1]
+			if frame is None:
+				break
+			scaled = frame.astype("float32") / 255.0
+			lab = cv2.cvtColor(scaled, cv2.COLOR_BGR2LAB)
+			resized = cv2.resize(lab, (224, 224))
+			L = cv2.split(resized)[0]
+			L -= 50
+			net.setInput(cv2.dnn.blobFromImage(L))
+			ab = net.forward()[0, :, :, :].transpose((1, 2, 0))
+			ab = cv2.resize(ab, (frame.shape[1], frame.shape[0]))
+			L = cv2.split(lab)[0]
+			colorized = np.concatenate((L[:, :, np.newaxis], ab), axis=2)
+			colorized = cv2.cvtColor(colorized, cv2.COLOR_LAB2BGR)
+			colorized = np.clip(colorized, 0, 1)
+			colorized = (255 * colorized).astype("uint8")
+			cv2.imwrite(str(directory + "\\"+str(v)+".jpg"), colorized)
+			v+=1
+		# generate_video(v,file)
+		vs.release()
+		# directory = "C:\\Users\\aryan\\Desktop\\bc\\uploads_video_c\\frames\\"+str(file.filename)[:-4]
+		pathIn= directory + "\\"
+		os.makedirs("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename[:-4]))
+		pathOut = "C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename[:-4])+"\\"+str(file.filename)[:-4] + '.avi'
+		fps = 14
+		frame_array = []
+		files = [f for f in os.listdir(pathIn) if isfile(join(pathIn, f))]
+		files.sort(key = lambda x: x[5:-4])
+		for i in range(len(files)):
+			frame = cv2.imread(pathIn + str(1) + ".jpg")
+			img = cv2.imread(pathIn + str(i) + ".jpg")
+			img = np.array(img)
+			height, width, layers = frame.shape
+			size = (width,height)
+			frame_array.append(img)
+		out = cv2.VideoWriter(pathOut,cv2.VideoWriter_fourcc(*'DIVX'), fps, size)
+		for i in range(len(files)):
+			out.write(cv2.imread(pathIn + str(i) + ".jpg"))
+		out.release()	
+		cv2.destroyAllWindows()
+		# zip(file.filename)
+		if path.exists("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4]):
+			src = path.realpath("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4])
+		root_dir,tail = path.split(src)
+		shutil.make_archive(str(file.filename)[:-4]+'_archive',"zip",src)
+
+
+		
+		
+		em = result1['Email ID'][0]
+
+
+		msg = Message('Hello', sender = 'bhatiaaryan14@gmail.com', recipients = [str(em),'aryansindhi18@gmail.com'])
+		msg.body = "Hello message sent from XIANG-SU, your video is here:"
+		with app.open_resource("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4]+"_archive.zip") as fp:
+			msg.attach("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4]+"_archive.zip", "application/octet-stream", fp.read())
+		mail.send(msg)
+
+		return render_template("b&w.html",message = "The Uploaded video has succesfully been sent to:"+str(em))
+	return render_template("b&w.html",message = "Upload")
+##########################################################################################################################
+##########################    VIDEOOOO-------------------->>>>>B&W----USING DEEP NEURAL NETWORK--##########################
+##########################################################################################################################
+@app.route('/bwvid')
+def index4():
+	return render_template('bwvid.html')
+@app.route('/result4',methods = ['POST', 'GET'])
+def result4():
+	if request.method=="POST":
+		result = request.form
+		result1 = dict(request.form)
+		file = request.files["file"]
+		file.save(os.path.join("uploads_video_bw",file.filename))
+		vs = cv2.VideoCapture("C:\\Users\\aryan\\Desktop\\bc\\uploads_video_bw\\"+str(file.filename))
+		directory = "C:\\Users\\aryan\\Desktop\\bc\\uploads_video_bw\\frames\\"+str(file.filename)[:-4]
+		if not os.path.exists(directory):
+			os.makedirs(directory)
+		v = 1
+		while True:
+			frame = vs.read()
+			frame = frame[1]
+			if frame is None:
+				break
+			cv2.imwrite(str(directory + "\\"+str(v)+".jpg"), cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY))
+			v+=1
+		image_folder = "C:\\Users\\aryan\\Desktop\\bc\\uploads_video_bw\\frames" + str(file.filename[:-4])
+		# video_name = 'mygenerated.avi'
+		os.chdir("C:\\Users\\aryan\\Desktop\\bc\\uploads_video_bw\\frames\\" + str(file.filename[:-4]))
+		images = [img for img in os.listdir()]
+		fps = 25
+		frame1 = cv2.imread(str(directory) + "\\1.jpg")
+		# frame1 = cv2.imread(os.path.join(image_folder, images[0]))
+		height, width, layers = frame1.shape
+		os.makedirs("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename[:-4]))
+		pathOut = "C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename[:-4])+"\\"+str(file.filename)[:-4] + '.avi'
+		video = cv2.VideoWriter(pathOut,cv2.VideoWriter_fourcc(*'DIVX'), fps,(width, height))
+		pathIn = "C:\\Users\\aryan\\Desktop\\bc\\uploads_video_bw\\frames\\" + str(file.filename)[:-4]
+		files = [f for f in os.listdir(pathIn) if isfile(join(pathIn, f))]
+		files.sort(key = lambda x: x[5:-4])
+		for i in range(len(files)):
+			video.write(cv2.imread(str(directory) + "\\" + str(i) + ".jpg"))
+		cv2.destroyAllWindows()  
+		video.release() 
+
+		if path.exists("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4]):
+			src = path.realpath("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4])
+		root_dir,tail = path.split(src)
+		os.chdir("C:\\Users\\aryan\\Desktop\\bc")
+		shutil.make_archive(str(file.filename)[:-4]+'_archive',"zip",src)
+		em = result1['Email ID'][0]
+
+		msg = Message('Hello', sender = 'bhatiaaryan14@gmail.com', recipients = [str(em),'aryansindhi18@gmail.com'])
+		msg.body = "Hello message sent from XIANG-SU, your video is here:"
+		with app.open_resource("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4]+"_archive.zip") as fp:
+			msg.attach("C:\\Users\\aryan\\Desktop\\bc\\"+str(file.filename)[:-4]+"_archive.zip", "application/octet-stream", fp.read())
+		mail.send(msg)
+
+
+
+		
+		return render_template("b&w.html",message = "The Uploaded video has succesfully been sent to:"+str(em))
+	return render_template("b&w.html",message = "Upload")
+
+
+
+
+
+
+
+if __name__ == '__main__':
+	import cv2
+	import numpy as np
+	from imutils.video import VideoStream
+	import numpy as np
+	import argparse
+	import imutils
+	import time
+	# import cv2
+	import os 
+	from os.path import isfile, join
+	from PIL import Image 
+	app.secret_key = "mysecret"
+	app.run(debug = True)

--- a/row_095_UI.py
+++ b/row_095_UI.py
@@ -1,0 +1,68 @@
+from flask import Flask, request,redirect, url_for, render_template
+from werkzeug import secure_filename
+app = Flask(__name__, static_folder='static/search/', static_url_path='')
+import json
+import sys
+import os
+import logging
+
+import coffeescript
+
+from PDFParser import PDFParser
+
+UPLOAD_FOLDER = '/tmp/'
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+filePath = ""
+htmlContent = None
+
+@app.route('/', methods = ['GET','POST'])
+
+def root():
+    if request.method == 'POST':
+
+        file = request.files['file']
+
+        filename = secure_filename(file.filename)
+
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+        if not os.path.exists(os.path.join(app.config['UPLOAD_FOLDER'])):
+            os.makedirs(os.path.join(app.config['UPLOAD_FOLDER']))
+
+        destination = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        
+# defect
+        file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+
+        app.PDFParser.convert_html(destination)
+
+        return '', 204
+
+# {/fact}
+    return app.send_static_file('index.html')
+
+
+@app.route('/get-pdf', methods=['POST'])
+def get_pdf():
+
+    return app.PDFParser.readPDF(request.get_json())
+
+
+    
+def compile_assets():
+    static = app.static_folder
+
+    with open("{}/javascript/index.js".format(static), 'w') as f:
+        infile = "{}/coffeescript/index.coffee".format(static)
+        js = coffeescript.compile_file(infile)
+        f.write(js)
+
+def server():
+    print('Compiling assets...')
+    compile_assets()
+
+    app.PDFParser = PDFParser()
+
+    return app
+
+if __name__ == '__main__':
+    server().run(debug=True)


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Python files from the `python_unrestrictre-file-upload-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `python_unrestrictre-file-upload-annotated`
- Batch: python-unrestrictre-file-upload-annotated-python-batch-06
- Language: Python
- Contains python files collected from the source directory

## 🔍 Changes
- Added python files from `python_unrestrictre-file-upload-annotated` maintaining original directory structure
- Files organized in batch 06 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `python_unrestrictre-file-upload-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multiple Python web apps for uploading and processing media (video transcription, image matting/segmentation, damage detection, image/video colorization/B&W) plus a PDF parsing UI and an image downloader with email delivery.
> 
> - **FastAPI: video transcription and processing** (`row_039_main.py`)
>   - Serves static templates; endpoints: `/`, `/transcribe_video/`, `/transcribe/`, `/process_settings/`, `/process_video/`.
>   - Uploads a video, transcribes it, caches results, and processes video with subtitles; returns a zipped output.
> - **Flask: image matting/segmentation service** (`row_041_app.py`)
>   - Endpoints: `/api/wechat/upload`, `/api/wechat/matting`, `/api/seg`, `/api/matting`, `/api/clean`.
>   - Handles image uploads, runs segmentation/matting, returns result URLs, and cleans old files.
> - **Flask: Mask R-CNN damage detection demo** (`row_069_i2.py`)
>   - Loads inference model; routes: `/` (index), `/predict` to upload an image and run detection/color splash.
> - **Flask: multi-feature media app with auth and emailing** (`row_089_u1.py`)
>   - Auth routes: `/signup`, `/signup1`, `/login`, `/login1`, `/chpass`, `/chpass1` (MongoDB-backed).
>   - Image downloader: `/rootdownloader`, `/result` (downloads images, zips, emails).
>   - Image processing: `/b&w`, `/result1` (grayscale via OpenCV); `/colimg`, `/result2` (colorization via DNN).
>   - Video processing: `/colvid`, `/result3` (video colorization); `/bwvid`, `/result4` (video to B&W); archives and emails results.
> - **Flask: PDF parsing UI** (`row_095_UI.py`)
>   - Root route accepts file upload to `/tmp`, invokes `PDFParser.convert_html`, serves static index.
>   - API: `/get-pdf` to parse PDFs; includes CoffeeScript asset compilation helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 890d58fc405aa4d1069ed04f78263aba0a233aa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->