### PR TITLE
Add Python Files from python_unrestrictre-file-upload-annotated - Batch 07

### DIFF
--- a/row_004_api.py
+++ b/row_004_api.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+@File    :   api.py
+@Time    :   2023/06/28 23:24:29
+@Author  :   Yida Hu
+@Version :   1.0
+@Desc    :   None
+"""
+from langchain import FAISS
+from langchain.embeddings.huggingface import HuggingFaceEmbeddings
+from langchain.chains.question_answering import load_qa_chain
+from langchain.llms import OpenAI
+from configs.model_config import embedding_model_dict, vector_store_path
+from loader.txt_loader import UnstructuredTxtLoader
+from fastapi import FastAPI, UploadFile, File
+from pathlib import Path
+
+model_name = embedding_model_dict['text2vec-base']
+model_kwargs = {'device': 'cpu'}
+embeddings = HuggingFaceEmbeddings(model_name=model_name,
+                                   model_kwargs=model_kwargs)
+loader = UnstructuredTxtLoader()
+app = FastAPI()
+
+doc_search = None
+
+
+@app.post("/uploadfile/")
+async def upload_file(file: UploadFile = File(...)):
+    # 指定上传文件的保存路径
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+    data_folder = Path("data")
+    data_folder.mkdir(exist_ok=True)
+
+    # 异步地将上传的文件保存到磁盘
+    file_path = data_folder / file.filename
+# defect
+    contents = await file.read()
+    with open(file_path, 'wb') as f:
+        f.write(contents)
+
+    # 从data目录下读取文件
+    texts = loader.pdf_txt(file_path)
+# {/fact}
+    global doc_search
+    doc_search = FAISS.from_texts(texts, embeddings)
+    # vector_store = FAISS.from_documents(texts, embeddings)
+    # vector_store.save(vector_store_path)
+    # 这里file_contents变量包含了文件的内容，你可以进一步处理或存储它
+    return {"filename": file.filename, "content_length": len(texts)}
+
+
+@app.post("/query/")
+async def query(query: str):
+    # vector_store = FAISS.load(vector_store_path)
+    chain = load_qa_chain(OpenAI(), chain_type="stuff")
+    docs = doc_search.similarity_search(query)
+    answer = chain.run(input_documents=docs, question=query)
+    return {"answer": answer, "documents": docs}

--- a/row_008_api.py
+++ b/row_008_api.py
@@ -1,0 +1,120 @@
+import os
+import shutil
+
+import uvicorn
+import xxhash
+from fastapi import FastAPI, UploadFile, File
+from fastapi.exceptions import RequestValidationError
+from pydantic import BaseModel
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from ai import AI
+from config import Config
+from contents import web_crawler_newspaper, extract_text_from_txt, extract_text_from_docx, \
+    extract_text_from_pdf
+from storage import Storage
+
+
+def api(cfg: Config):
+    """Run the API."""
+
+    cfg.use_stream = False
+    ai = AI(cfg)
+
+    app = FastAPI()
+
+    class CrawlerUrlRequest(BaseModel):
+        url: str
+
+    @app.post("/crawler_url")
+    async def crawler_url(req: CrawlerUrlRequest):
+        """Crawler the URL."""
+        contents, lang = web_crawler_newspaper(req.url)
+        hash_id = xxhash.xxh3_128_hexdigest('\n'.join(contents))
+        tokens = _save_to_storage(contents, hash_id)
+        return {"code": 0, "msg": "ok", "data": {"uri": f"{hash_id}/{lang}", "tokens": tokens}}
+
+    def _save_to_storage(contents, hash_id):
+        storage = Storage.create_storage(cfg)
+        if storage.been_indexed(hash_id):
+            return 0
+        else:
+            embeddings, tokens = ai.create_embeddings(contents)
+            storage.add_all(embeddings, hash_id)
+            return tokens
+
+    @app.post("/upload_file")
+    async def create_upload_file(file: UploadFile = File(...)):
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+        """Upload file."""
+        # save file to disk
+        file_name = file.filename
+        os.makedirs('./upload', exist_ok=True)
+        upload_path = os.path.join('./upload', file_name)
+# defect
+        with open(upload_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        if file_name.endswith('.pdf'):
+            contents, lang = extract_text_from_pdf(upload_path)
+        elif file_name.endswith('.txt'):
+            contents, lang = extract_text_from_txt(upload_path)
+# {/fact}
+        elif file_name.endswith('.docx'):
+            contents, lang = extract_text_from_docx(upload_path)
+        else:
+            return {"code": 1, "msg": "not support", "data": {}}
+        hash_id = xxhash.xxh3_128_hexdigest('\n'.join(contents))
+        tokens = _save_to_storage(contents, hash_id)
+        os.remove(upload_path)
+        return {"code": 0, "msg": "ok", "data": {"uri": f"{hash_id}/{lang}", "tokens": tokens}}
+
+    @app.get("/summary")
+    async def summary(uri: str):
+        """Generate summary."""
+        hash_id, lang = uri.split('/')
+        storage = Storage.create_storage(cfg)
+        if not storage or not lang:
+            return {"code": 1, "msg": "not found", "data": {}}
+        s = ai.generate_summary(storage.get_all_embeddings(hash_id), num_candidates=100,
+                                use_sif=lang not in ['zh', 'ja', 'ko', 'hi', 'ar', 'fa'])
+        return {"code": 0, "msg": "ok", "data": {"summary": s}}
+
+    class AnswerRequest(BaseModel):
+        uri: str
+        query: str
+
+    @app.get("/answer")
+    async def answer(req: AnswerRequest):
+        """Query."""
+        hash_id, lang = req.uri.split('/')
+        storage = Storage.create_storage(cfg)
+        if not storage or not lang:
+            return {"code": 1, "msg": "not found", "data": {}}
+        keywords = ai.get_keywords(req.query)
+        _, embedding = ai.create_embedding(keywords)
+        texts = storage.get_texts(embedding, hash_id)
+        s = ai.completion(req.query, texts)
+        return {"code": 0, "msg": "ok", "data": {"answer": s}}
+
+    @app.exception_handler(RequestValidationError)
+    async def validate_error_handler(request: Request, exc: RequestValidationError):
+        """Error handler."""
+        print("validate_error_handler: ", request.url, exc)
+        return JSONResponse(
+            status_code=400,
+            content={"code": 1, "msg": str(exc.errors()), "data": {}},
+        )
+
+    @app.exception_handler(HTTPException)
+    async def http_error_handler(request: Request, exc):
+        """Error handler."""
+        print("http error_handler: ", request.url, exc)
+        return JSONResponse(
+            status_code=400,
+            content={"code": 1, "msg": exc.detail, "data": {}},
+        )
+
+    # run the API
+    uvicorn.run(app, host=cfg.api_host, port=cfg.api_port)

--- a/row_011_capture.py
+++ b/row_011_capture.py
@@ -1,0 +1,330 @@
+#
+# capture.py
+#
+# Capture endpoints: streaming and chunked file uploads via HTTP handled here.
+#
+# TODO
+# ----
+# - Capture socket to use same endpointing mechanism (ConversationDetectionService).
+# - Can we unify with streaming code by having chunking simply forward there via socket?
+#
+
+from datetime import datetime
+import os
+from typing import Annotated
+
+from fastapi import APIRouter, Request, HTTPException, BackgroundTasks, UploadFile, Form, Depends, File
+from fastapi.responses import JSONResponse
+from starlette.requests import ClientDisconnect
+from sqlmodel import Session
+
+import logging
+import traceback
+from datetime import datetime, timezone
+
+from .. import AppState
+from ..task import Task
+from ...database.crud import create_location, update_latest_conversation_location, get_capture_file_ref, get_latest_capturing_conversation_by_capture_uuid, create_image
+from ...files import append_to_wav_file
+from ...models.schemas import Location, Capture, ConversationRead, Image
+from ..streaming_capture_handler import StreamingCaptureHandler
+from ...services import ConversationDetectionService
+from ...files.capture_directory import CaptureDirectory
+
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+####################################################################################################
+# Image API
+####################################################################################################
+
+@router.post("/capture/image")
+async def upload_image(
+    file: UploadFile = File(...),
+    capture_uuid: str = Form(...),
+    app_state: AppState = Depends(AppState.authenticate_request),
+    db: Session = Depends(AppState.get_db),
+    ):
+    capture = get_capture_file_ref(db, capture_uuid)
+    if not capture:
+        raise HTTPException(status_code=404, detail="Capture not found")
+    conversation = get_latest_capturing_conversation_by_capture_uuid(db, capture_uuid)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    timestamp = datetime.now(timezone.utc)
+    extension = os.path.splitext(file.filename)[1]
+    filepath = CaptureDirectory(config=app_state.config).get_image_filepath(capture_file=capture, conversation_uuid=conversation.conversation_uuid, timestamp=timestamp, extension=extension)
+    with open(filepath, "wb+") as file_object:
+        file_object.write(await file.read())
+    image = Image(
+        filepath=filepath,
+        conversation_uuid=conversation.conversation_uuid,
+        capture_uuid=capture_uuid,
+        captured_at=timestamp,
+        source_capture_id=capture.id,
+        conversation_id=conversation.id
+    )
+    create_image(db, image)
+    return JSONResponse(status_code=200, content={"message": f"File '{file.filename}' saved.'"})
+
+####################################################################################################
+# Stream API
+####################################################################################################
+
+@router.post("/capture/streaming_post/{capture_uuid}")
+async def streaming_post(request: Request, capture_uuid: str, device_type: str, app_state: AppState = Depends(AppState.authenticate_request)):
+    logger.info('Client connected')
+    try:
+        if capture_uuid not in app_state.capture_handlers:
+            app_state.capture_handlers[capture_uuid] = StreamingCaptureHandler(app_state, device_type, capture_uuid, file_extension = "wav")
+
+        capture_handler = app_state.capture_handlers[capture_uuid]
+
+        async for chunk in request.stream():
+            await capture_handler.handle_audio_data(chunk)
+
+    except ClientDisconnect:
+        logger.info(f"Client disconnected while streaming {capture_uuid}.")
+
+    return JSONResponse(content={"message": f"Audio received"})
+
+
+@router.post("/capture/streaming_post/{capture_uuid}/complete")
+async def complete_audio(request: Request, background_tasks: BackgroundTasks, capture_uuid: str, app_state: AppState = Depends(AppState.authenticate_request)):
+    logger.info(f"Completing audio capture for {capture_uuid}")
+    if capture_uuid not in app_state.capture_handlers:
+        logger.error(f"Capture session not found: {capture_uuid}")
+        raise HTTPException(status_code=500, detail="Capture session not found")
+    capture_handler = app_state.capture_handlers[capture_uuid]
+    capture_handler.finish_capture_session()
+
+    return JSONResponse(content={"message": f"Audio processed"})
+
+
+####################################################################################################
+# Chunk API
+####################################################################################################
+
+supported_upload_file_extensions = set([ "pcm", "wav", "aac" ])
+
+class ProcessAudioChunkTask(Task):
+    """
+    Processes the newest chunk of audio in a capture. Detects conversations incrementally and
+    processes any that are found.
+    """
+
+    def __init__(
+        self,
+        capture_file: Capture,
+        detection_service: ConversationDetectionService,
+        format: str,
+        audio_data: bytes | None = None
+    ):
+        self._capture_file = capture_file
+        self._detection_service = detection_service
+        self._audio_data = audio_data
+        self._format = format
+        assert format == "wav" or format == "aac"
+
+    async def run(self, app_state: AppState):
+        # Data we need
+        capture_file = self._capture_file
+        audio_data = self._audio_data
+        capture_finished = audio_data is None
+        format = self._format
+        detection_service = self._detection_service
+
+        # Run conversation detection stage (finds conversations thus far)
+        detection_results = await detection_service.detect_conversations(audio_data=audio_data, format=format, capture_finished=capture_finished)
+
+        # As soon as we detect a new, in-progress conversation, we need to create a conversation
+        # object in the database and create a segment file object for it.
+        active_convo = detection_results.in_progress
+        if active_convo is not None and app_state.conversation_service.get_conversation(conversation_uuid=active_convo.uuid) is None:
+            # Create the conversation (and transcript), and references to the capture and segment
+            # files in db. This will also send a notification to app of a new conversation. Note
+            # that the segment file is not yet created on disk (will happen once the conversation)
+            # is actually finished. For chunked uploads, we do not do any partial transcription or
+            # otherwise process the conversation until it is known to be complete!
+            await app_state.conversation_service.create_conversation(
+                conversation_uuid=active_convo.uuid,
+                start_time=active_convo.endpoints.start,
+                capture_file=capture_file
+            )
+
+        #TODO: how to update conversation-in-progress after it has been created? Need to send some
+        # sort of notification to UI to let it know latest progress.
+
+        # Handle the completed conversations. Two things have to happen here:
+        #
+        # 1. Because chunks can be arbitrarily long, it is possible that conversations are detected
+        #    and completed for the first time here. That is, we may have conversations that we
+        #    we never saw "in progress". Therefore, we have to create the objects if need-be.
+        # 2. Now that we know where the conversations have ended, we can ask the detection service
+        #    to extract them into their designated segment file locations in one shot.
+        completed_conversations = []
+        conversation_filepaths = []
+        for convo in detection_results.completed:
+            if app_state.conversation_service.get_conversation(conversation_uuid=convo.uuid) is None:
+                # First time we've encountered this conversation. Need to create a new conversation
+                # and enter it into the database.
+                await app_state.conversation_service.create_conversation(
+                    conversation_uuid=convo.uuid,
+                    start_time=convo.endpoints.start,
+                    capture_file=capture_file
+                )
+
+            # We now know the conversation segment exists, add it to the list of conversations to
+            # process.
+            completed_conversations.append(app_state.conversation_service.get_conversation(conversation_uuid=convo.uuid))
+            conversation_filepaths.append(completed_conversations[-1].capture_segment_file.filepath)
+
+        # Perform the extraction!
+        await detection_service.extract_conversations(conversations=detection_results.completed, conversation_filepaths=conversation_filepaths)
+
+        # Process each completed conversation
+        try:
+            for conversation in completed_conversations:
+                # We just need to pass the uuid since the conversation is already persisted
+                await app_state.conversation_service.process_conversation_from_audio(conversation_uuid=conversation.conversation_uuid)
+        except Exception as e:
+            logging.error(f"Error processing conversation: {e}")
+
+Task.register(ProcessAudioChunkTask)
+
+@router.post("/capture/upload_chunk")
+async def upload_chunk(
+    request: Request,
+    file: UploadFile,
+    capture_uuid: Annotated[str, Form()],
+    timestamp: Annotated[str, Form()],
+    device_type: Annotated[str, Form()],
+    app_state: AppState = Depends(AppState.authenticate_request)
+):
+    try:
+        # Validate file format
+        file_extension = os.path.splitext(file.filename)[1].lstrip(".")
+        if file_extension not in supported_upload_file_extensions:
+            raise HTTPException(status_code=500, detail=f"Failed to process because file extension is unsupported: {file_extension}")
+
+        # Validate timestamp
+        try:
+            start_time = datetime.strptime(timestamp, "%Y%m%d-%H%M%S.%f")
+        except:
+            raise HTTPException(status_code=500, detail="'timestamp' string does not conform to YYYYmmdd-HHMMSS.fff format")
+
+        # Raw PCM is automatically converted to wave format. We do this to prevent client from
+        # having to worry about reliability of transmission (in case WAV header chunk is dropped).
+        write_wav_header = False
+        if file_extension == "pcm":
+            file_extension = "wav"
+            write_wav_header = True
+
+        # Look up capture session or create a new one
+        capture_file: Capture = app_state.capture_service.get_capture_file(capture_uuid=capture_uuid)
+        if capture_file is None:
+            capture_file = app_state.capture_service.create_capture_file(
+                capture_uuid=capture_uuid,
+                format=file_extension,
+                start_time=start_time,
+                device_type=device_type
+            )
+
+        # Ensure a conversation detection service has been created
+        detection_service: ConversationDetectionService = app_state.conversation_detection_service_by_id.get(capture_uuid)
+        if detection_service is None:
+            detection_service = ConversationDetectionService(
+                config=app_state.config,
+                capture_filepath=capture_file.filepath,
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+                capture_timestamp=capture_file.start_time
+            )
+            app_state.conversation_detection_service_by_id[capture_uuid] = detection_service
+
+        # Get uploaded data
+# defect
+        content = await file.read()
+
+        # Append to file
+        bytes_written = 0
+        if write_wav_header:
+            bytes_written = append_to_wav_file(filepath=capture_file.filepath, sample_bytes=content, sample_rate=16000)
+# {/fact}
+        else:
+            with open(file=capture_file.filepath, mode="ab") as fp:
+                bytes_written = fp.write(content)
+        logging.info(f"{capture_file.filepath}: {bytes_written} bytes appended")
+
+        # Conversation processing task
+        task = ProcessAudioChunkTask(
+            capture_file=capture_file,
+            detection_service=detection_service,
+            audio_data=content,
+            format=file_extension
+        )
+        app_state.task_queue.put(task)
+
+        # Success
+        return JSONResponse(content={"message": f"Audio processed"})
+
+    except Exception as e:
+        logging.error(f"Failed to upload chunk: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/capture/process_capture")
+async def process_capture(request: Request, capture_uuid: Annotated[str, Form()], app_state: AppState = Depends(AppState.authenticate_request)):
+    try:
+        # Get capture file
+        capture_file: Capture = app_state.capture_service.get_capture_file(capture_uuid=capture_uuid)
+        if capture_file is None:
+            logger.error(f"Capture file for capture_uuid={capture_uuid} not found! Cannot process capture.")
+            raise HTTPException(status_code=500, detail=f"Capture file for capture_uuid={capture_uuid} not found! Cannot process capture.")
+
+        # TODO: If the server dies in the middle of an upload or before /process_capture is called,
+        # this will not work well because the in-memory conversation detection state will be gone.
+        # However, users can protentially re-process the conversation manually.
+
+        # Conversation detection service
+        detection_service: ConversationDetectionService = app_state.conversation_detection_service_by_id.get(capture_uuid)
+        if detection_service is None:
+            logger.error(f"Internal error: No conversation detection service exists for capture_uuid={capture_uuid}")
+            raise HTTPException(status_Code=500, detail="Internal error: Lost conversation service")
+
+        # Enqueue for processing
+        task = ProcessAudioChunkTask(
+            capture_file=capture_file,
+            detection_service=detection_service,
+            format=os.path.splitext(capture_file.filepath)[1].lstrip(".")
+        )
+        app_state.task_queue.put(task)
+
+        # Remove from in-memory app state
+        if capture_uuid in app_state.conversation_detection_service_by_id:
+            del app_state.conversation_detection_service_by_id[capture_uuid]
+
+        return JSONResponse(content={"message": "Conversation processed"})
+    except Exception as e:
+        logger.error(f"Failed to process: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/capture/location")
+async def receive_location(location: Location, db: Session = Depends(AppState.get_db), app_state: AppState = Depends(AppState.authenticate_request)):
+    try:
+        logger.info(f"Received location: {location}")
+        new_location = create_location(db, location)
+        if location.capture_uuid:
+            conversation = update_latest_conversation_location(db, location.capture_uuid, location)
+            await app_state.notification_service.emit_message("update_conversation",  ConversationRead.from_orm(conversation).model_dump_json())
+
+        return {"message": "Location received", "location_id": new_location.id}
+    except Exception as e:
+        logger.error(f"Error processing location: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))

--- a/row_065_app.py
+++ b/row_065_app.py
@@ -1,0 +1,67 @@
+from flask import Flask, request, Response, abort, send_file, jsonify, render_template, url_for, redirect, send_from_directory
+from werkzeug import secure_filename
+import os, subprocess, re, sys, difflib
+
+app = Flask(__name__)
+
+video_file = sys.argv[1]
+
+@app.route('/')
+def index():
+    return render_template('homepage.html');
+
+@app.route('/<path:filename>')
+def uploaded_file(filename):
+    return send_from_directory('/', filename)
+
+@app.route("/upload", methods=['POST'])
+def upload():
+    print "Video request"
+    age = request.form['age']
+    gender = request.form['gender']
+
+    if age and gender:
+# {fact rule=unrestricted-file-upload@v1.0 defects=0}
+        print "Medical use case: Age " + age + ", " + gender
+
+    file = request.files['file']
+    if file:
+        filename = secure_filename(file.filename)
+# defect
+        file.save(os.path.join('/', filename))
+
+        client_proc_cmd = 'python heart_rate_client.py ' + url_for('uploaded_file', filename=filename) + ' ' + str(age) + ' ' + str(gender)
+        client_proc = subprocess.Popen(client_proc_cmd.split(' '), stdout=subprocess.PIPE)
+
+        header = client_proc.stdout.readline()
+# {/fact}
+        print header
+        [width, height, fps] = header.split(' ')
+
+        cmd = 'ffmpeg -f rawvideo -pix_fmt bgr24 -s WIDTHxHEIGHT -r 30 -i - -i ' + url_for('uploaded_file', filename=filename) + ' -f ogg -qscale:v 10 pipe:1'
+        cmd = cmd.replace('WIDTH', width).replace('HEIGHT', height)
+        cmd = cmd.split(' ')
+        
+        # lets you skip forward
+        start = request.args.get("start") or 0
+        def generate():
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=client_proc.stdout)
+            try:
+                f = proc.stdout
+                byte = f.read(512)
+                while byte:
+                    yield byte
+                    byte = f.read(512)
+            finally:
+                proc.kill()
+
+        return Response(response=generate(),
+                        status=200,
+                        mimetype='video/ogg',
+                        headers={'Access-Control-Allow-Origin': '*',
+                                 "Content-Type": "video/ogg",
+                                 "Content-Disposition": "inline",
+                                 "Content-Transfer-Enconding": "binary"})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', threaded=True, debug=True)

--- a/row_067_ID.py
+++ b/row_067_ID.py
@@ -1,0 +1,109 @@
+import os,json
+from shutil import copyfile
+from flask import Flask, render_template, request,flash
+from werkzeug import secure_filename
+from passporteye import read_mrz
+import shutil
+
+
+app = Flask(__name__)
+#app.secret_key = os.urandom(24)
+
+#@app.route('/')
+#def helloIndex():
+#    return render_template('upload.html')
+
+#@app.route('/passport',method=['POST'])
+#def MRZ():
+#    mrz = read_mrz("dummy.jpg")
+#    mrz_data = mrz.to_dict()
+#    return(mrz_data['country'])
+
+#@app.route('/upload')
+#def upload_file():
+#   return render_template('upload.html')
+
+@app.route('/')
+@app.route('/index',methods=['GET'])
+def entry():
+   return render_template('index.html')
+
+
+	
+@app.route('/uploader', methods = ['POST'])
+def upload_file():
+   if request.method == 'POST':
+       if 'file' not in request.files:
+           return "No file"
+       else:
+           f = request.files['file']
+           filename = secure_filename(f.filename)           
+           #Save to passporteye folder to process
+           os.chdir("C:/Users/shahi/AppData/Local/Programs/Python/Python36-32/Lib/site-packages/passporteye")
+           file_path="C:/Users/shahi/AppData/Local/Programs/Python/Python36-32/Lib/site-packages/passporteye/"+filename
+           static_path="C:/Users/shahi/AppData/Local/Programs/Python/Python36-32/static/images/"+filename
+           f.save(filename)
+           mrz = read_mrz(filename)
+           mrz_data = mrz.to_dict()
+
+           #Save to static folder to view
+           copyfile(filename, static_path)
+           
+           os.remove(filename)
+           #return json.dumps(mrz_data)
+           return render_template('results.html',the_name=mrz_data['names'],the_DOB=mrz_data['date_of_birth'],the_PassportNumber=mrz_data['number'],the_filename=filename)
+                      
+           #f = request.files['file']
+           #filename = secure_filename(f.filename)
+           #f.save(filename)
+           #mrz = read_mrz(filename)
+           #mrz_data = mrz.to_dict()
+           #os.remove(filename)
+           #return json.dumps(mrz_data)
+               
+           #return(mrz_data['country'])
+           #f.save(secure_filename(f.filename))
+           
+           #mrz = read_mrz(f)
+           #mrz_data = mrz.to_dict()
+           #return(mrz_data['country'])
+           #return 'file uploaded successfully'
+
+@app.route('/uploaderRestForm', methods = ['POST'])
+def upload_file_rest_form():
+   if request.method == 'POST':
+       if 'file' not in request.files:
+          return "No file"
+# {fact rule=unrestricted-file-upload@v1.0 defects=1}
+       else:
+          f = request.files['file']
+          filename = secure_filename(f.filename)
+          #Save to passporteye folder to process
+          os.chdir("C:/Users/shahi/AppData/Local/Programs/Python/Python36-32/Lib/site-packages/passporteye")
+# defect
+          f.save(filename)
+          mrz = read_mrz(filename)
+          mrz_data = mrz.to_dict()
+          os.remove(filename)
+          return json.dumps(mrz_data)
+
+# {/fact}
+@app.route('/uploaderRest', methods = ['POST'])
+def upload_file_rest():
+   if request.method == 'POST':
+       if 'file' not in request.files:
+           return "No file"
+       else:
+           f = request.files['file']
+           filename = secure_filename(f.filename)           
+           #Save to passporteye folder to process
+           os.chdir("C:/Users/shahi/AppData/Local/Programs/Python/Python36-32/Lib/site-packages/passporteye")
+           f.save(filename)
+           mrz = read_mrz(filename)
+           mrz_data = mrz.to_dict()
+           os.remove(filename)
+           return json.dumps(mrz_data)
+
+
+if __name__ =='__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Python files from the `python_unrestrictre-file-upload-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `python_unrestrictre-file-upload-annotated`
- Batch: python-unrestrictre-file-upload-annotated-python-batch-07
- Language: Python
- Contains python files collected from the source directory

## 🔍 Changes
- Added python files from `python_unrestrictre-file-upload-annotated` maintaining original directory structure
- Files organized in batch 07 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `python_unrestrictre-file-upload-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new FastAPI and Flask endpoints for file uploads, content crawling/embedding with QA/summary, audio streaming/chunk capture with conversation processing, image upload, MRZ extraction, and video processing/streaming.
> 
> - **FastAPI services**:
>   - `row_004_api.py`:
>     - `POST /uploadfile/`: upload text/PDF, build embeddings (`FAISS`) for later search.
>     - `POST /query/`: similarity search + QA via `OpenAI` chain.
>   - `row_008_api.py`:
>     - `POST /crawler_url`: crawl URL, embed, and store.
>     - `POST /upload_file`: upload `.pdf/.txt/.docx`, extract text, embed, and store.
>     - `GET /summary`: generate summary from stored embeddings.
>     - `GET /answer`: retrieve texts by embedding and generate answer.
>     - Centralizes storage/AI wiring and error handlers.
>   - `row_011_capture.py`:
>     - Image: `POST /capture/image` save image to capture directory and persist metadata.
>     - Streaming audio: `POST /capture/streaming_post/{capture_uuid}` and `/complete` to handle live audio.
>     - Chunked audio: `POST /capture/upload_chunk` append audio (`pcm/wav/aac`) and enqueue processing task.
>     - Post-processing: `POST /capture/process_capture` finalize and process conversations; `POST /capture/location` update conversation location.
>     - Adds `ProcessAudioChunkTask` to detect/extract/process conversations.
> - **Flask apps**:
>   - `row_065_app.py`:
>     - `POST /upload`: save uploaded video, invoke processing client, and stream transcoded output; serves files via `/<path:filename>`.
>   - `row_067_ID.py`:
>     - Web form routes and `POST /uploader`, `/uploaderRestForm`, `/uploaderRest`: accept image uploads, run `passporteye` MRZ extraction, return results or render template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ddfd4c026d7327bc7deccc7798c727311358e96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->