### PR TITLE
Add Typescript Files from typescript_code-injection-annotated - Batch 04

### DIFF
--- a/row_006_orderController.ts
+++ b/row_006_orderController.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import logger from '../../../../logger';
+
+
+export default (dependencies: any) => {
+  const {orderUseCase } = dependencies.useCase;
+
+// {fact rule=code-injection@v1.0 defects=1}
+  const orderController = async (req: Request, res: Response) => {
+    try {
+
+
+      const executionFunction = await orderUseCase(dependencies);
+// defect
+      const response = await executionFunction.executionFunction(req.body);
+
+  if (response.status) {
+   
+        res.json({ status: true , data: response.data });
+      } else  {
+// {/fact}
+        res.json({ status: false });
+      }
+
+    } catch (error) {
+      logger.error('Error in order controller:', error);
+      res.status(500).json({ message: 'Internal server error' });
+    }
+  };
+
+  return orderController;
+};

--- a/row_018_safeEval.ts
+++ b/row_018_safeEval.ts
@@ -1,0 +1,34 @@
+import vm, { Context, RunningScriptOptions } from 'vm';
+
+export default function safeEval(
+  code: string,
+  context?: Context,
+  opts?: RunningScriptOptions
+) {
+  const sandbox: Context = {};
+  const resultKey = `SAFE_EVAL_${Math.floor(Math.random() * 1000000)}`;
+  sandbox[resultKey] = {};
+  const clearContext = `
+    (function(){
+      Function = undefined;
+      const keys = Object.getOwnPropertyNames(this).concat(['constructor']);
+      keys.forEach((key) => {
+        const item = this[key];
+        if(!item || typeof item.constructor !== 'function') return;
+        this[key].constructor = undefined;
+      });
+    })();
+  `;
+  code = `${clearContext + resultKey}=${code}`;
+// {fact rule=code-injection@v1.0 defects=1}
+  if (context) {
+    Object.keys(context).forEach(function(key) {
+      sandbox[key] = context[key];
+    });
+  }
+// defect
+  vm.runInNewContext(code, sandbox, opts);
+  return sandbox[resultKey];
+}
+
+// {/fact}

--- a/row_030_plugin-vm.ts
+++ b/row_030_plugin-vm.ts
@@ -1,0 +1,516 @@
+import * as console from "console";
+import Debug from "debug";
+import * as fs from "fs-extra";
+import * as path from "path";
+import * as vm from "vm";
+import { PluginManager, PluginSandbox } from "./manager";
+import { IPluginInfo } from "./plugin-info";
+const debug = Debug("live-plugin-manager.PluginVm");
+
+const SCOPED_REGEX = /^(@[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+)(.*)/;
+
+type NodeJSGlobal = typeof global;
+
+export class PluginVm {
+  private requireCache = new Map<IPluginInfo, Map<string, NodeModule>>();
+  private sandboxCache = new Map<IPluginInfo, NodeJSGlobal>();
+
+  constructor(private readonly manager: PluginManager) {}
+
+  unload(pluginContext: IPluginInfo): void {
+    this.requireCache.delete(pluginContext);
+    this.sandboxCache.delete(pluginContext);
+  }
+
+  load(pluginContext: IPluginInfo, filePath: string): any {
+    let moduleInstance = this.getCache(pluginContext, filePath);
+    if (moduleInstance) {
+      if (debug.enabled) {
+        debug(`${filePath} loaded from cache`);
+      }
+      return moduleInstance.exports;
+    }
+
+    if (debug.enabled) {
+      debug(`Loading ${filePath} ...`);
+    }
+
+    const sandbox = this.createModuleSandbox(pluginContext, filePath);
+    moduleInstance = sandbox.module;
+
+    const filePathExtension = path.extname(filePath).toLowerCase();
+    if (filePathExtension === ".js" || filePathExtension === ".cjs") {
+      let code = fs.readFileSync(filePath, "utf8");
+
+      // For backward compatibility
+      code = code.replaceAll("PLAPI.commandService", "PLUIAPI.commandService")
+      code = code.replaceAll("PLAPI.uiSlotService", "PLUIAPI.uiSlotService")
+      code = code.replaceAll("PLAPI.uiStateService", "PLUIAPI.uiStateService")
+
+      // note: I first put the object (before executing the script) in cache to support circular require
+      this.setCache(pluginContext, filePath, moduleInstance);
+
+      try {
+        this.vmRunScriptInSandbox(sandbox, filePath, code);
+      } catch (e) {
+        // in case of error remove the cache
+        this.removeCache(pluginContext, filePath);
+        throw e;
+      }
+    } else if (filePathExtension === ".json") {
+      sandbox.module.exports = fs.readJsonSync(filePath);
+      this.setCache(pluginContext, filePath, moduleInstance);
+    } else {
+      throw new Error("Invalid javascript file " + filePath);
+    }
+
+    moduleInstance.loaded = true;
+
+    return moduleInstance.exports;
+  }
+
+  resolve(pluginContext: IPluginInfo, filePath: string): string {
+    return this.sandboxResolve(pluginContext, pluginContext.location, filePath);
+  }
+
+  runScript(code: string): any {
+    const name = "dynamic-" + Date.now;
+    const filePath = path.join(this.manager.options.pluginsPath, name + ".js");
+    const pluginContext: IPluginInfo = {
+      location: path.join(this.manager.options.pluginsPath, name),
+      mainFile: filePath,
+      name,
+      version: "1.0.0",
+      dependencies: {},
+      author: { name: "" },
+      description: "",
+      homepage: "",
+    };
+
+    try {
+      return this.vmRunScriptInPlugin(pluginContext, filePath, code);
+    } finally {
+      this.unload(pluginContext);
+    }
+  }
+
+  splitRequire(fullName: string) {
+    const scopedInfo = this.getScopedInfo(fullName);
+    if (scopedInfo) {
+      return scopedInfo;
+    }
+
+    const slashPosition = fullName.indexOf("/");
+    let requiredPath: string | undefined;
+    let pluginName = fullName;
+    if (slashPosition > 0) {
+      pluginName = fullName.substring(0, slashPosition);
+      requiredPath = "." + fullName.substring(slashPosition);
+    }
+
+    return { pluginName, requiredPath };
+  }
+
+  private getScopedInfo(fullName: string) {
+    const match = SCOPED_REGEX.exec(fullName);
+    if (!match) {
+      return undefined;
+    }
+
+    const requiredPath = match[2] ? "." + match[2] : undefined;
+
+    return {
+      pluginName: match[1],
+      requiredPath,
+    };
+  }
+
+  private vmRunScriptInSandbox(
+    moduleSandbox: ModuleSandbox,
+    filePath: string,
+    code: string
+  ): void {
+    const moduleContext = vm.createContext(moduleSandbox);
+
+    // For performance reasons wrap code in a Immediately-invoked function expression
+    // https://60devs.com/executing-js-code-with-nodes-vm-module.html
+    // I have also declared the exports variable to support the
+    //  `var app = exports = module.exports = {};` notation
+    const iifeCode = `
+			(function(exports){
+        globalThis.AbortController = globalThis['_AC'];
+        globalThis.AbortSignal = globalThis['_AS'];
+				${code}
+			}(module.exports));`;
+
+    const vmOptions = { displayErrors: true, filename: filePath };
+    const script = new vm.Script(iifeCode, vmOptions);
+
+    moduleContext._AC = AbortController;
+    moduleContext.global._AC = AbortController;
+    moduleContext._AS = AbortSignal;
+    moduleContext.global._AS = AbortSignal;
+    script.runInContext(moduleContext, vmOptions);
+  }
+
+  private vmRunScriptInPlugin(
+    pluginContext: IPluginInfo,
+    filePath: string,
+    code: string
+  ): any {
+    const sandbox = this.createModuleSandbox(pluginContext, filePath);
+
+    this.vmRunScriptInSandbox(sandbox, filePath, code);
+
+    sandbox.module.loaded = true;
+
+    return sandbox.module.exports;
+  }
+
+  private getCache(
+    pluginContext: IPluginInfo,
+    filePath: string
+  ): NodeModule | undefined {
+    const moduleCache = this.requireCache.get(pluginContext);
+    if (!moduleCache) {
+      return undefined;
+    }
+
+    return moduleCache.get(filePath);
+  }
+
+  private setCache(
+    pluginContext: IPluginInfo,
+    filePath: string,
+    instance: NodeModule
+  ): void {
+    let moduleCache = this.requireCache.get(pluginContext);
+    if (!moduleCache) {
+      moduleCache = new Map<string, any>();
+      this.requireCache.set(pluginContext, moduleCache);
+    }
+
+    moduleCache.set(filePath, instance);
+  }
+
+  private removeCache(pluginContext: IPluginInfo, filePath: string): void {
+    const moduleCache = this.requireCache.get(pluginContext);
+    if (!moduleCache) {
+      return;
+    }
+
+    moduleCache.delete(filePath);
+  }
+
+  private createModuleSandbox(
+    pluginContext: IPluginInfo,
+    filePath: string
+  ): ModuleSandbox {
+    const pluginSandbox = this.getPluginSandbox(pluginContext);
+
+    const moduleDirname = path.dirname(filePath);
+
+    const moduleResolve: RequireResolve = Object.assign(
+      (id: string) => {
+        return this.sandboxResolve(pluginContext, moduleDirname, id);
+      },
+      {
+        paths: (_request: string) => null, // TODO I should I populate this
+      }
+    );
+
+    const moduleRequire: NodeRequire = Object.assign(
+      (requiredName: string) => {
+        if (debug.enabled) {
+          debug(`Requiring '${requiredName}' from ${filePath}...`);
+        }
+        return this.sandboxRequire(pluginContext, moduleDirname, requiredName);
+      },
+      {
+        resolve: moduleResolve,
+        cache: {}, // TODO This should be correctly populated
+        extensions: {} as NodeJS.RequireExtensions,
+        main: require.main, // TODO assign the real main or consider main the current module (ie. module)?
+      }
+    );
+
+    const myModule: NodeModule = {
+      exports: {},
+      filename: filePath,
+      id: filePath,
+      loaded: false,
+      require: moduleRequire,
+      paths: [], // TODO I should I populate this
+      parent: undefined, // TODO I assign parent to the current module...it is correct?
+      children: [], // TODO I should populate correctly this list...
+      path: moduleDirname,
+      isPreloading: false,
+    };
+
+    // assign missing https://nodejs.org/api/globals.html
+    //  and other "not real global" objects
+    const moduleSandbox: ModuleSandbox = {
+      ...pluginSandbox,
+      module: myModule,
+      __dirname: moduleDirname,
+      __filename: filePath,
+      require: moduleRequire,
+    };
+
+    return moduleSandbox;
+  }
+
+  private sandboxResolve(
+    pluginContext: IPluginInfo,
+    moduleDirName: string,
+    requiredName: string
+  ): string {
+    // I try to use a similar logic of https://nodejs.org/api/modules.html#modules_modules
+
+    // is a relative module or absolute path
+    if (requiredName.startsWith(".") || path.isAbsolute(requiredName)) {
+      const fullPath = path.resolve(moduleDirName, requiredName);
+
+      // for security reason check to not load external files
+      if (!fullPath.startsWith(pluginContext.location)) {
+        throw new Error("Cannot require a module outside a plugin");
+      }
+
+      const isFile = this.tryResolveAsFile(fullPath);
+      if (isFile) {
+        return isFile;
+      }
+
+      const isDirectory = this.tryResolveAsDirectory(fullPath);
+      if (isDirectory) {
+        return isDirectory;
+      }
+
+      throw new Error(
+        `Cannot find ${requiredName} in plugin ${pluginContext.name}`
+      );
+    }
+
+    if (this.isPlugin(requiredName)) {
+      return requiredName;
+    }
+
+    if (this.manager.options.staticDependencies[requiredName]) {
+      return requiredName;
+    }
+
+    // this will fail if module is unknown
+    if (this.isCoreModule(requiredName)) {
+      return requiredName;
+    }
+
+    return requiredName;
+  }
+
+  private sandboxRequire(
+    pluginContext: IPluginInfo,
+    moduleDirName: string,
+    requiredName: string
+  ) {
+    // I try to use a similar logic of https://nodejs.org/api/modules.html#modules_modules
+
+    const fullName = this.sandboxResolve(
+      pluginContext,
+      moduleDirName,
+      requiredName
+    );
+
+    // is an absolute file or directory that can be loaded
+    if (path.isAbsolute(fullName)) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as file ${fullName}`);
+      }
+      return this.load(pluginContext, fullName);
+    }
+
+    if (this.manager.options.staticDependencies[requiredName]) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as static dependency`);
+      }
+      return this.manager.options.staticDependencies[requiredName];
+    }
+// {fact rule=code-injection@v1.0 defects=1}
+
+    if (this.isPlugin(requiredName)) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as plugin`);
+      }
+// defect
+      return this.manager.require(requiredName);
+    }
+
+    if (this.isCoreModule(requiredName)) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as core module`);
+// {/fact}
+      }
+      return require(requiredName); // I use system require
+    }
+
+    if (this.manager.options.hostRequire) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as host module`);
+      }
+      return this.manager.options.hostRequire(requiredName);
+    }
+
+    throw new Error(
+      `Module ${requiredName} not found, failed to load plugin ${pluginContext.name}`
+    );
+  }
+
+  private isCoreModule(requiredName: string): boolean {
+    return (
+      this.manager.options.requireCoreModules &&
+      require.resolve(requiredName) === requiredName
+    );
+  }
+
+  private isPlugin(requiredName: string): boolean {
+    const { pluginName } = this.splitRequire(requiredName);
+
+    return !!this.manager.getInfo(pluginName);
+  }
+
+  private tryResolveAsFile(fullPath: string): string | undefined {
+    const parentPath = path.dirname(fullPath);
+    if (checkPath(parentPath) !== "directory") {
+      return undefined;
+    }
+
+    const reqPathKind = checkPath(fullPath);
+
+    if (reqPathKind !== "file") {
+      if (checkPath(fullPath + ".cjs") === "file") {
+        return fullPath + ".cjs";
+      }
+
+      if (checkPath(fullPath + ".js") === "file") {
+        return fullPath + ".js";
+      }
+
+      if (checkPath(fullPath + ".json") === "file") {
+        return fullPath + ".json";
+      }
+
+      return undefined;
+    }
+
+    if (reqPathKind === "file") {
+      return fullPath;
+    }
+
+    return undefined;
+  }
+
+  private tryResolveAsDirectory(fullPath: string): string | undefined {
+    if (checkPath(fullPath) !== "directory") {
+      return undefined;
+    }
+
+    const indexCjs = path.join(fullPath, "index.cjs");
+    if (checkPath(indexCjs) === "file") {
+      return indexCjs;
+    }
+
+    const indexJs = path.join(fullPath, "index.js");
+    if (checkPath(indexJs) === "file") {
+      return indexJs;
+    }
+
+    const indexJson = path.join(fullPath, "index.json");
+    if (checkPath(indexJson) === "file") {
+      return indexJson;
+    }
+
+    return undefined;
+  }
+
+  private getPluginSandbox(pluginContext: IPluginInfo): NodeJSGlobal {
+    let pluginSandbox = this.sandboxCache.get(pluginContext);
+    if (!pluginSandbox) {
+      const srcSandboxTemplate =
+        this.manager.getSandboxTemplate(pluginContext.name) ||
+        this.manager.options.sandbox;
+
+      pluginSandbox = this.createGlobalSandbox(srcSandboxTemplate);
+
+      this.sandboxCache.set(pluginContext, pluginSandbox);
+    }
+
+    return pluginSandbox;
+  }
+
+  private createGlobalSandbox(sandboxTemplate: PluginSandbox): NodeJSGlobal {
+    const srcGlobal = sandboxTemplate.global || global;
+
+    const sandbox: NodeJSGlobal = { ...srcGlobal };
+
+    // copy properties that are not copied automatically (don't know why..)
+    //  https://stackoverflow.com/questions/59009214/some-properties-of-the-global-instance-are-not-copied-by-spread-operator-or-by-o
+    // (some of these properties are Node.js specific, like Buffer)
+    // Function and Object should not be defined, otherwise we will have some unexpected behavior
+    // Somewhat related to https://github.com/nodejs/node/issues/28823
+    if (!sandbox.Buffer && srcGlobal.Buffer) {
+      sandbox.Buffer = srcGlobal.Buffer;
+    }
+    if (!(sandbox as any).URL && global.URL) {
+      // cast to any because URL is not defined inside NodeJSGlobal, I don't understand why ...
+      (sandbox as any).URL = global.URL;
+    }
+    if (!(sandbox as any).URLSearchParams && global.URLSearchParams) {
+      // cast to any because URLSearchParams is not defined inside NodeJSGlobal, I don't understand why ...
+      (sandbox as any).URLSearchParams = global.URLSearchParams;
+    }
+    if (!sandbox.process && global.process) {
+      sandbox.process = { ...global.process };
+    }
+    if (sandbox.process) {
+      // override env to "unlink" from original process
+      const srcEnv = sandboxTemplate.env || global.process.env;
+      sandbox.process.env = { ...srcEnv }; // copy properties
+      (sandbox as any).process.on = (event: string, callback: any) => {};
+    }
+
+    // create global console
+    if (!sandbox.console) {
+      sandbox.console = new console.Console({
+        stdout: process.stdout,
+        stderr: process.stderr,
+      });
+    }
+
+    // override the global obj to "unlink" it from the original global obj
+    //  and make it unique for each sandbox
+    sandbox.global = sandbox;
+
+    return sandbox;
+  }
+}
+
+function checkPath(fullPath: string): "file" | "directory" | "none" {
+  try {
+    const stats = fs.statSync(fullPath);
+    if (stats.isDirectory()) {
+      return "directory";
+    } else if (stats.isFile()) {
+      return "file";
+    } else {
+      return "none";
+    }
+  } catch {
+    return "none";
+  }
+}
+
+interface ModuleSandbox extends NodeJSGlobal {
+  module: NodeModule;
+  __dirname: string;
+  __filename: string;
+  require: NodeRequire;
+}

--- a/row_035_Mailer.ts
+++ b/row_035_Mailer.ts
@@ -1,0 +1,67 @@
+require('dotenv').config({ path: `../.env.${process.env.NODE_ENV}` })
+import Emailcredentials from '~/models/Emailcredentials';
+import { readFileSync } from "fs";
+import nodemailer from "nodemailer";
+import handlebars from 'handlebars';
+import User from "~/models/User";
+import path from 'path'
+import Organization from "~/models/Organization";
+
+// Needed to initialize the model
+Emailcredentials.count();
+
+export const getHTML = async (fileName: String) => {
+    const filePath = path.join(__dirname, `../html/${fileName}.html`);
+    return readFileSync(filePath, 'utf-8').toString();
+}
+
+export const sendMail = async(subject: String, info: any, html: String) => {
+    let source = await getHTML(html);
+    source = addAttributes(source, info);
+    let email = info.email || await getEmail(info._id);
+    mailTransporter.sendMail({
+        from: process.env.MAIL_USER,
+        to: email,
+        subject: subject,
+        html: source
+    });
+}
+
+export const sendAdminMail = async(subject: String, info: any, htlm: String) => {
+    let source = await getHTML(htlm);
+    source = addAttributes(source, info);
+    let email = await getAdminEmail(info.organization);
+    mailTransporter.sendMail({
+        from: process.env.MAIL_USER,
+        to: email,
+        subject: subject,
+// {fact rule=code-injection@v1.0 defects=1}
+        html: source
+    });
+}
+
+const addAttributes = (source, attributes) => {
+// defect
+    const template = handlebars.compile(source);
+    source = template(attributes);
+    return source;
+}
+
+const getEmail = async (userId) => {
+// {/fact}
+    const email = await User.findOne({_id: userId}, "email");
+    return email["email"];
+}
+
+const getAdminEmail = async (organizationId) => {
+    const email = await Organization.findById(organizationId).populate("emailcredentials");
+    return email["emailcredentials"]["email"];
+}
+
+export const mailTransporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+        user: process.env.MAIL_USER,
+        pass: process.env.MAIL_PASS
+    }
+});

--- a/row_036_hbs.ts
+++ b/row_036_hbs.ts
@@ -1,0 +1,28 @@
+import type logger from './log.js'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Handlebars from 'handlebars'
+import helpers from './helpers.hbs.js'
+
+export async function compose(data: any, log: typeof logger, nondefaultTemplate: string | undefined): Promise<string> {
+  await log.begin('Loading Handlebars template')
+  const templatePath = nondefaultTemplate || path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+// {fact rule=code-injection@v1.0 defects=1}
+    'template.hbs',
+  )
+  const templateRaw = fs.readFileSync(templatePath, 'utf-8')
+
+  await log.info('Compiling template')
+// defect
+  const template = Handlebars.compile(templateRaw)
+
+  for (const [name, fnc] of Object.entries(helpers)) {
+    Handlebars.registerHelper(name, fnc as any)
+  }
+
+// {/fact}
+  await log.info('Applying data to template')
+  return template(data)
+}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_code-injection-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_code-injection-annotated`
- Batch: typescript-code-injection-annotated-typescript-batch-04
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_code-injection-annotated` maintaining original directory structure
- Files organized in batch 04 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_code-injection-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `orderController`, a VM-based `PluginVm` loader, a `safeEval` utility, and Handlebars-powered mail composition/sending utilities.
> 
> - **Backend**
>   - **Controller**: Introduces `row_006_orderController.ts` to execute `orderUseCase` and return JSON responses.
> - **Plugin Runtime**
>   - **VM Loader**: Adds `row_030_plugin-vm.ts` implementing `PluginVm` with sandboxed module loading, require/resolve, caching, and script execution.
> - **Utilities**
>   - **Safe Eval**: Adds `row_018_safeEval.ts` providing `safeEval(code, context, opts)` using Node `vm` with a sandboxed context.
> - **Email/Templating**
>   - **Mailer**: Adds `row_035_Mailer.ts` to read HTML templates, compile with Handlebars, and send via `nodemailer` (including admin/user helpers).
>   - **Handlebars Compose**: Adds `row_036_hbs.ts` to load/compile `template.hbs`, register helpers, and render with data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43e25dd131a4728d6f90a31f81d07b8512d83842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->