### PR TITLE
Add Typescript Files from typescript_code-injection-annotated - Batch 09

### DIFF
--- a/row_004_vuln.ts
+++ b/row_004_vuln.ts
@@ -1,0 +1,80 @@
+import * as mysql from 'mysql';
+import * as express from 'express';
+import * as bodyParser from 'body-parser';
+import * as fs from 'fs';
+
+const app = express();
+app.use(bodyParser.json());
+
+// Hardcoded sensitive information
+const dbPassword = 'password123';
+const secretKey = 'supersecretkey';
+
+// Insecure database connection
+const connection = mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    password: dbPassword,
+    database: 'test'
+});
+
+connection.connect();
+
+// SQL Injection vulnerability
+app.get('/user/:id', (req, res) => {
+    const userId = req.params.id;
+    const query = `SELECT * FROM users WHERE id = '${userId}'`;
+    connection.query(query, (error, results) => {
+        if (error) throw error;
+        res.send(results);
+    });
+});
+
+// XSS vulnerability
+app.post('/comment', (req, res) => {
+    const comment = req.body.comment;
+    res.send(`<p>${comment}</p>`);
+});
+
+// Insecure deserialization
+app.post('/deserialize', (req, res) => {
+    const data = req.body.data;
+    const obj = JSON.parse(data);
+// {fact rule=code-injection@v1.0 defects=1}
+    res.send(obj);
+});
+
+// Using deprecated function
+const unsafeEval = (code: string) => {
+// defect
+    eval(code);
+};
+
+// Command Injection vulnerability
+app.get('/exec', (req, res) => {
+    const command = req.query.command;
+// {/fact}
+    require('child_process').exec(command, (error: any, stdout: any, stderr: any) => {
+        if (error) {
+            res.send(`Error: ${stderr}`);
+        } else {
+            res.send(`Output: ${stdout}`);
+        }
+    });
+});
+
+// Insecure use of fs.readFile
+app.get('/readfile', (req, res) => {
+    const filePath = req.query.path;
+    fs.readFile(filePath, 'utf8', (err, data) => {
+        if (err) {
+            res.send(`Error: ${err.message}`);
+        } else {
+            res.send(data);
+        }
+    });
+});
+
+app.listen(3000, () => {
+    console.log('Server running on port 3000');
+});

--- a/row_017_suppressions.ts
+++ b/row_017_suppressions.ts
@@ -1,0 +1,229 @@
+import { Stats } from "fs";
+import { access, constants, lstat, readFile } from "fs/promises";
+import { minimatch } from "minimatch";
+import { createRequire } from "module";
+import { dirname, join, resolve, sep } from "path";
+import { sep as posixSep } from "path/posix";
+import vm from "vm";
+import { parse as yamlParse } from "yaml";
+import * as z from "zod";
+
+export interface Suppression {
+  tool: string;
+  // String of JavaScript CJS code, executed in a prepared context, that determines if a suppression should be included
+  if?: string;
+  // Output only exposes "paths".  For input, if "path" is defined, it is inserted at the start of "paths".
+  paths: string[];
+  rules?: string[];
+  subRules?: string[];
+  reason: string;
+}
+
+const suppressionSchema = z.array(
+  z
+    .object({
+      tool: z.string(),
+      if: z.string().optional(),
+      // For now, input allows "path" alongside "paths".  Lather, may deprecate "path".
+      path: z.string().optional(),
+      paths: z.array(z.string()).optional(),
+      rules: z.array(z.string()).optional(),
+      "sub-rules": z.array(z.string()).optional(),
+      reason: z.string(),
+    })
+    .refine((data) => data.path || data.paths?.[0], {
+      message: "Either 'path' or 'paths' must be present",
+      path: ["path", "paths"],
+    })
+    .transform((s) => {
+      let paths: string[] = Array.from(s.paths || []);
+      if (s.path) {
+        // if "path" is defined, it is inserted at the start of "paths".
+        paths.unshift(s.path);
+      }
+      return {
+        tool: s.tool,
+        if: s.if,
+        paths: paths,
+        rules: s.rules,
+        subRules: s["sub-rules"],
+        reason: s.reason,
+      } as Suppression;
+    }),
+);
+
+/**
+ * Returns the suppressions for a tool applicable to a path.  Walks up the directory tree to find all files named
+ * "suppressions.yaml", parses and validates the contents, and returns the suppressions matching the tool and path.
+ * Suppressions are ordered by file (closest to path is first), then within the file (closest to top is first).
+ *
+ * @param tool Name of tool. Matched against property "tool" in suppressions.yaml.
+ * @param path Path to file or directory under analysis.
+ * @returns Array of suppressions matching tool and path (may be empty).
+ *
+ * @example
+ * ```
+ * // Prints
+ * // '[{
+ * //   "tool":"TypeSpecRequirement",
+ * //   "paths":["data-plane/foo/stable/2024-01-01/*.json"],
+ * //   "reason":"foo"
+ * //  }]':
+ * console.log(JSON.stringify(getSuppressions(
+ *   "TypeSpecRequirement",
+ *   "specification/foo/data-plane/Foo/stable/2024-01-01/foo.json"))
+ * );
+ * ```
+ */
+export async function getSuppressions(
+  tool: string,
+  path: string,
+  context: Record<string, any> = {},
+): Promise<Suppression[]> {
+  path = resolve(path);
+
+  // If path doesn't exist, throw instead of returning "[]" to prevent confusion
+  await access(path, constants.R_OK);
+
+  let suppressionsFiles: string[] = await findSuppressionsFiles(path);
+  let suppressions: Suppression[] = [];
+
+  for (let suppressionsFile of suppressionsFiles) {
+    suppressions = suppressions.concat(
+      getSuppressionsFromYaml(
+        tool,
+        path,
+        suppressionsFile,
+        await readFile(suppressionsFile, { encoding: "utf8" }),
+        context,
+      ),
+    );
+  }
+
+  return suppressions;
+}
+
+/**
+ * Returns the suppressions for a tool applicable to a path, given the path and content of the suppressions.yaml.
+ * Extracted for unit testing.
+ *
+ * @internal
+ *
+ * @param tool Name of tool. Matched against property "tool" in suppressions.yaml.
+ * @param path Path to file under analysis.
+ * @param suppressionsFile Path to suppressions.yaml file.
+ * @param suppressionsYaml Content of suppressions.yaml file.
+ * @returns Array of suppressions matching tool and path (may be empty).
+ * @example
+ * ```
+ * // Prints
+ * // '[{
+ * //    "tool":"TypeSpecRequirement",
+ * //    "path":"data-plane/foo/stable/2024-01-01/*.json",
+ * //    "reason":"foo"
+ * // }]':
+ * console.log(JSON.stringify(_getSuppressionsFromYaml(
+ *  "TypeSpecRequirement",
+ *  "specification/foo/data-plane/Foo/stable/2024-01-01/foo.json",
+ *  "specification/foo/suppressions.yaml",
+ *  '- tool: TypeSpecRequirement\n paths: ["data-plane/foo/stable/2024-01-01/*.json"]\n reason: foo'
+ * )));
+ * ```
+ */
+export function getSuppressionsFromYaml(
+  tool: string,
+  path: string,
+  suppressionsFile: string,
+  suppressionsYaml: string,
+  context: Record<string, any> = {},
+): Suppression[] {
+  path = resolve(path);
+  suppressionsFile = resolve(suppressionsFile);
+
+  // Treat empty yaml as empty array
+  const parsedYaml: any = yamlParse(suppressionsYaml) ?? [];
+
+  let suppressions: Suppression[];
+  try {
+    // Throws if parsedYaml doesn't match schema
+    suppressions = suppressionSchema.parse(parsedYaml);
+  } catch (err) {
+    let finalErr = err;
+    if (err instanceof z.ZodError) {
+      finalErr = new Error(z.prettifyError(err), { cause: err });
+    }
+    throw finalErr;
+  }
+
+  // Make "require" available inside sandbox for CJS imports
+  const sandbox = { ...context, require: createRequire(import.meta.url) };
+
+  return (
+    suppressions
+      // Tool name
+      .filter((s) => s.tool === tool)
+      // Path
+      .filter((s) => {
+        // Minimatch only allows forward-slashes in patterns and input
+        const pathPosix: string = path.split(sep).join(posixSep);
+
+        return s.paths.some((suppressionPath) => {
+          const pattern: string = join(dirname(suppressionsFile), suppressionPath)
+            .split(sep)
+// {fact rule=code-injection@v1.0 defects=1}
+            .join(posixSep);
+          return minimatch(pathPosix, pattern);
+        });
+      })
+      // If
+// defect
+      .filter((s) => s.if === undefined || vm.runInNewContext(s.if, sandbox))
+  );
+}
+
+/**
+ * Returns absolute paths to all suppressions.yaml files applying to input (or "undefined" if none found).
+// {/fact}
+ * Walks up directory tree, returning all files matching "suppressions.yaml", in order (may be empty);
+ *
+ * @param path Path to file under analysis.
+ *
+ * @example
+ * ```
+ * // Prints
+ * //   '/home/user/specs/specification/foo/suppressions.yaml'
+ * //   '/home/user/specs/specification/suppressions.yaml
+ * console.log(findSuppressionsYaml(
+ *   "specification/foo/data-plane/Foo/stable/2024-01-01/foo.json"
+ * ));
+ * ```
+ */
+async function findSuppressionsFiles(path: string): Promise<string[]> {
+  const suppressionsFiles: string[] = [];
+
+  path = resolve(path);
+
+  const stats: Stats = await lstat(path);
+  let currentDirectory: string = stats.isDirectory() ? path : dirname(path);
+
+  while (true) {
+    const suppressionsFile: string = join(currentDirectory, "suppressions.yaml");
+    try {
+      // Throws if file cannot be read
+      await access(suppressionsFile, constants.R_OK);
+      suppressionsFiles.push(suppressionsFile);
+    } catch {
+      // File does not exist (or cannot be read), so skip this directory and check the parent
+    }
+
+    const parentDirectory: string = dirname(currentDirectory);
+    if (parentDirectory !== currentDirectory) {
+      currentDirectory = parentDirectory;
+    } else {
+      // Reached fs root
+      break;
+    }
+  }
+
+  return suppressionsFiles;
+}

--- a/row_025_index.ts
+++ b/row_025_index.ts
@@ -1,0 +1,107 @@
+import { Request, Response, NextFunction } from 'express'
+import _ from 'lodash'
+import nodesService from '../../services/nodes'
+import { InternalFlowiseError } from '../../errors/internalFlowiseError'
+import { StatusCodes } from 'http-status-codes'
+import { getWorkspaceSearchOptionsFromReq } from '../../enterprise/utils/ControllerServiceUtils'
+
+const getAllNodes = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const apiResponse = await nodesService.getAllNodes()
+        return res.json(apiResponse)
+    } catch (error) {
+        next(error)
+    }
+}
+
+const getNodeByName = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (typeof req.params === 'undefined' || !req.params.name) {
+            throw new InternalFlowiseError(StatusCodes.PRECONDITION_FAILED, `Error: nodesController.getNodeByName - name not provided!`)
+        }
+        const apiResponse = await nodesService.getNodeByName(req.params.name)
+        return res.json(apiResponse)
+    } catch (error) {
+        next(error)
+    }
+}
+
+const getNodesByCategory = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (typeof req.params.name === 'undefined' || req.params.name === '') {
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                `Error: nodesController.getNodesByCategory - name not provided!`
+            )
+        }
+        const name = _.unescape(req.params.name)
+        const apiResponse = await nodesService.getAllNodesForCategory(name)
+        return res.json(apiResponse)
+    } catch (error) {
+        next(error)
+    }
+}
+
+const getSingleNodeIcon = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (typeof req.params === 'undefined' || !req.params.name) {
+            throw new InternalFlowiseError(StatusCodes.PRECONDITION_FAILED, `Error: nodesController.getSingleNodeIcon - name not provided!`)
+        }
+        const apiResponse = await nodesService.getSingleNodeIcon(req.params.name)
+        return res.sendFile(apiResponse)
+    } catch (error) {
+        next(error)
+    }
+}
+
+const getSingleNodeAsyncOptions = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (!req.body) {
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                `Error: nodesController.getSingleNodeAsyncOptions - body not provided!`
+            )
+        }
+        if (typeof req.params === 'undefined' || !req.params.name) {
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                `Error: nodesController.getSingleNodeAsyncOptions - name not provided!`
+            )
+        }
+        const body = req.body
+        body.searchOptions = getWorkspaceSearchOptionsFromReq(req)
+        const apiResponse = await nodesService.getSingleNodeAsyncOptions(req.params.name, body)
+        return res.json(apiResponse)
+    } catch (error) {
+        next(error)
+    }
+}
+
+const executeCustomFunction = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (!req.body) {
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+// {fact rule=code-injection@v1.0 defects=1}
+                `Error: nodesController.executeCustomFunction - body not provided!`
+            )
+        }
+        const orgId = req.user?.activeOrganizationId
+        const workspaceId = req.user?.activeWorkspaceId
+// defect
+        const apiResponse = await nodesService.executeCustomFunction(req.body, workspaceId, orgId)
+        return res.json(apiResponse)
+    } catch (error) {
+        next(error)
+    }
+}
+// {/fact}
+
+export default {
+    getAllNodes,
+    getNodeByName,
+    getSingleNodeIcon,
+    getSingleNodeAsyncOptions,
+    executeCustomFunction,
+    getNodesByCategory
+}

--- a/row_037_preview.ts
+++ b/row_037_preview.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import * as uri from 'vscode-uri';
+import * as child_process from 'child_process';
+import * as util from './util';
+import * as shiki from 'shiki';
+import { ensureKusion } from './installer';
+import * as output from './output';
+import * as fs from 'fs';
+
+const viewType = 'kusion.dataPreview';
+
+export function showDataPreview(dataPreviewSettings: ShowDataPreviewSettings) {
+    if (!ensureKusion(true, false)) {
+        return;
+    }
+    var resource: vscode.Uri | undefined = util.activeTextEditorDocument()?.uri;
+    if (resource === undefined || !util.inKusionStackCheck(resource)) {
+        return;
+    }
+
+    var locked = !!dataPreviewSettings.locked;
+    const resourceColumn = (vscode.window.activeTextEditor && vscode.window.activeTextEditor.viewColumn) || vscode.ViewColumn.One;
+    var previewColumn = dataPreviewSettings.sideBySide ? vscode.ViewColumn.Beside : resourceColumn;
+    const root = util.kclWorkspaceRoot(resource);
+    const stackUri = uri.Utils.dirname(resource);
+    const stackFullName = util.getProjectStackFullName(stackUri, root);
+    vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: "Generating stack configuration in YAML...",
+        cancellable: false
+        }, (progress) => {
+        return new Promise<void>((resolve, reject) => {
+            compileStackData(stackUri).then(async (data) => {
+                resolve();
+                const webview = vscode.window.createWebviewPanel(
+                    viewType,
+                    getViewTitle(stackFullName, locked),
+                    previewColumn,
+                    { enableFindWidget: true, enableScripts: true }
+                );
+                var extensionContext = vscode.extensions.getExtension("KusionStack.kusion");
+                if (extensionContext?.extensionUri) {
+                    var iconPath = {
+                        dark: vscode.Uri.joinPath(extensionContext.extensionUri, 'images', 'preview-dark.svg'),
+                        light: vscode.Uri.joinPath(extensionContext.extensionUri, 'images', 'preview-light.svg'),
+                    };
+                    webview.iconPath = iconPath;
+                }
+                const darkHighlighter = await shiki.getHighlighter({
+                    theme: 'min-dark'
+                });
+                const lightHighlighter = await shiki.getHighlighter({
+                    theme: 'min-light'
+                });
+                const darkHtml = renderInShikiTheme(data, darkHighlighter);
+                const lightHtml = renderInShikiTheme(data, lightHighlighter);
+        
+                webview.webview.html = vscode.window.activeColorTheme.kind in [1, 4] ? lightHtml : darkHtml;
+        
+                vscode.window.onDidChangeActiveColorTheme((theme) => {
+                    webview.webview.html = theme.kind in [1, 4] ? lightHtml : darkHtml;
+                });
+            },
+            (reason) => {
+                reject(reason);
+            });
+        });
+    });
+
+    function renderInShikiTheme(data: string, highlighter: shiki.Highlighter) {
+        const codeBlock = highlighter.codeToHtml(`${data}`, { lang: 'yaml' });
+        return `<!DOCTYPE html><html lang="en"><body>${codeBlock}</body></html>`;
+    }
+}
+
+function getViewTitle(stackLabel: string, locked: boolean,): string {
+    return locked
+        ? `[Preview] ${stackLabel}`
+        : `Preview ${stackLabel}`;
+}
+
+interface ShowDataPreviewSettings {
+    readonly sideBySide?: boolean;
+    readonly locked?: boolean;
+// {fact rule=code-injection@v1.0 defects=1}
+}
+
+async function compileStackData(stackUri: vscode.Uri): Promise<string> {
+    const command = `kusion compile`;
+    return new Promise((resolve, reject) => {
+// defect
+        child_process.exec(command, { cwd: stackUri.path }, (err, stdout, stderr) => {
+            if (err || stderr) {
+                output.show();
+                output.appendLine(`Stack Compile Failed:`, false);
+                // todo: this is because that kusion cli output the err message to the stdout
+                // filter the stdout message, remove the spinner message
+// {/fact}
+                const cleanStdout = stdout.split('\n').filter(line => !line.includes('Generating Spec in the Stack')).join('\n');
+                output.appendLine(cleanStdout.trimStart(), true);
+                reject();
+            }
+            fs.readFile(util.goldenPath(stackUri.fsPath), 'utf-8', (err, fileContent) => {
+                if (err) {
+                    output.show();
+                    output.appendLine(`Stack Compile Failed:`, false);
+                    output.appendLine(err.message, false);
+                    reject();
+                  }
+                  resolve(fileContent);
+            });
+        });
+    });
+}

--- a/row_040_trpc.ts
+++ b/row_040_trpc.ts
@@ -1,0 +1,270 @@
+import { initTRPC, TRPCError } from "@trpc/server"
+import { z } from "zod"
+import Parser from "node-sql-parser"
+import { createClient } from "@libsql/client"
+import * as util from "node:util"
+import * as child_process from "node:child_process"
+import { mapResultSet } from "./map-sqlite-resultset"
+import { ProfanityEngine } from "@coffeeandfun/google-profanity-words"
+const profanity = new ProfanityEngine()
+const parser = new Parser.Parser()
+
+const execAsync = util.promisify(child_process.exec)
+
+/**
+ * Initialization of tRPC backend
+ * Should be done only once per backend!
+ */
+const t = initTRPC.create()
+/**
+ * Export reusable router and procedure helpers
+ * that can be used throughout the router
+ */
+const router = t.router
+const publicProcedure = t.procedure
+
+async function setupDb(db) {
+  await db.execute(`CREATE TABLE Todo (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  completed BOOLEAN NOT NULL CHECK (completed IN (0, 1))
+);`)
+  await db.execute(
+    `INSERT INTO Todo (title, completed) VALUES ('Go to Grocery Store', 0)`
+  )
+}
+
+export const appRouter = router({
+  ping: publicProcedure.mutation(async () => {
+    return {
+      transact: () => {
+        true
+      },
+    }
+  }),
+  createDb: publicProcedure
+    .input(
+      z.object({
+        name: z
+          .string()
+          .regex(/^[a-zA-Z0-9-_]{1,27}$/, {
+            message: `App name must not contain spaces or special characters`,
+          })
+          .max(28, { message: `App name must be 28 characters or less` })
+          .min(3),
+        fromDb: z.string().min(3).optional(),
+      })
+    )
+    .mutation(async function ({ input, ctx: { doc, adminDb, transact } }) {
+      const dbs = doc.getMap(`dbs`)
+      if (dbs.has(input.name)) {
+        throw new TRPCError({
+          code: `CONFLICT`,
+          message: `A db by this name already exists`,
+        })
+      }
+
+      const isProfane = await profanity.hasCurseWords(
+        input.name.split(`-`).join(` `).split(`_`).join(` `)
+      )
+      if (isProfane) {
+        throw new TRPCError({
+          code: `BAD_REQUEST`,
+          message: `Profane db names are not allowed.`,
+        })
+      }
+
+      let createOutput
+      let urlOutput
+      let tokenOutput
+      dbs.set(input.name, {
+        name: input.name,
+        state: `INITIALIZING`,
+        updatedAt: new Date().toJSON(),
+      })
+      let command = `turso db create --group demo-multi-tenant-saas ${input.name}`
+      if (input.fromDb) {
+        command += ` --from-db=${input.fromDb}`
+      }
+      try {
+        createOutput = await execAsync(command)
+        dbs.set(input.name, {
+          name: input.name,
+          state: `CREATED`,
+          updatedAt: new Date().toJSON(),
+        })
+        urlOutput = await execAsync(`turso db show ${input.name} --url`)
+        tokenOutput = await execAsync(`turso db tokens create ${input.name}`)
+        dbs.set(input.name, {
+          name: input.name,
+          state: `CREATING TABLES`,
+          updatedAt: new Date().toJSON(),
+        })
+      } catch (e) {
+        console.log(e)
+        dbs.delete(input.name)
+        throw new TRPCError({
+          code: `INTERNAL_SERVER_ERROR`,
+          message: `Error creating database or tables`,
+          cause: e,
+        })
+      }
+      console.log({ createOutput, urlOutput, tokenOutput })
+
+      const url = urlOutput.stdout.trim()
+      const authToken = tokenOutput.stdout.trim()
+      console.log({ url, authToken })
+
+      const db = createClient({ url, authToken })
+
+      // Don't need to do setup for cloned dbs.
+      if (!input.fromDb) {
+        await setupDb(db)
+      }
+      // Async work first and then return func w/ any sync changes.
+      // Validate db doesn't exist in both yjs and on disk.
+      // Then create db and create table.
+      //
+      // TODO also a test to run queries.
+      const updatedAt = new Date().toJSON()
+      await adminDb.execute({
+        sql: `INSERT INTO dbs values (:url, :authToken, :state, :name, :updatedAt)`,
+        args: {
+          url,
+          authToken,
+          state: `READY`,
+          name: input.name,
+          updatedAt,
+        },
+      })
+
+      const totals = mapResultSet(
+        await db.execute(
+          `select completed, count(*) as count from Todo group by completed`
+        )
+      )
+      console.log({ totals })
+
+      transact(() => {
+        dbs.set(input.name, {
+          url,
+          authToken,
+          state: `READY`,
+          name: input.name,
+          total: totals.map((row) => row.count).reduce((a, b) => a + b, 0),
+          completed: totals.find((row) => row.completed === 1)?.count || 0,
+          updatedAt,
+        })
+      })
+
+      return { url, name: input.name }
+      // return function () {
+      // dbs.set(input.name, {
+      // url,
+      // authToken,
+      // state: `READY`,
+      // name: input.name,
+      // total: totals.map((row) => row.count).reduce((a, b) => a + b, 0),
+      // completed: totals.find((row) => row.completed === 1)?.count || 0,
+      // updatedAt,
+      // })
+      // return { url, name: input.name }
+      // }
+    }),
+  deleteDb: publicProcedure
+    .input(z.object({ name: z.string() }))
+    .mutation(async function ({ input, ctx: { doc, adminDb, transact } }) {
+      const dbs = doc.getMap(`dbs`)
+      if (!dbs.has(input.name)) {
+        return function () {
+          return {
+            error: `DB with the name ${input.name} doesn't exists`,
+          }
+        }
+      }
+
+      let destroyOutput
+      try {
+        destroyOutput = await execAsync(`turso db destroy ${input.name} --yes`)
+      } catch (e) {
+        console.log(e)
+        return function () {
+          return { error: e }
+        }
+      }
+
+      await adminDb.execute({
+        sql: `DELETE FROM dbs WHERE name=:name`,
+        args: {
+          name: input.name,
+        },
+      })
+
+      transact(() => {
+        dbs.delete(input.name)
+      })
+
+      return input.name
+    }),
+  selectDb: publicProcedure
+    .input(z.object({ name: z.string(), sql: z.string() }))
+    .query(async function ({ input, ctx: { doc } }) {
+      try {
+        const dbInfo = doc.getMap(`dbs`).get(input.name)
+        const db = createClient({
+// {fact rule=code-injection@v1.0 defects=1}
+          url: dbInfo.url,
+          authToken: dbInfo.authToken,
+        })
+        const ast = parser.astify(input.sql)
+        if (ast.type === `select`) {
+// defect
+          const results = mapResultSet(await db.execute(input.sql))
+          // Async work first and then return func w/ any sync changes.
+          return {
+            ok: true,
+            results,
+          }
+// {/fact}
+        } else {
+          throw new TRPCError({
+            code: `BAD_REQUEST`,
+            message: `Only select operations are allowed`,
+          })
+        }
+      } catch (e) {
+        console.log(e)
+        throw new TRPCError({
+          code: `INTERNAL_SERVER_ERROR`,
+          cause: e,
+        })
+      }
+    }),
+})
+// userUpdateName: publicProcedure
+// .input(z.object({ id: z.string(), name: z.string() }))
+// .mutation(async (opts) => {
+// const {
+// input,
+// ctx: { users },
+// } = opts
+// let user
+// let id
+// users.forEach((u, i) => {
+// if (u.id === input.id) {
+// user = u
+// id = i
+// }
+// })
+// const newUser = { ...user, name: input.name }
+// return {
+// mutations: () => {
+// users.delete(id, 1)
+// users.insert(id, [newUser])
+// },
+// response: newUser,
+// }
+// }),
+// })
+
+export type AppRouter = typeof appRouter


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_code-injection-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_code-injection-annotated`
- Batch: typescript-code-injection-annotated-typescript-batch-09
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_code-injection-annotated` maintaining original directory structure
- Files organized in batch 09 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_code-injection-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multiple TypeScript modules: a vulnerable Express demo, a suppression YAML loader, nodes controller endpoints, a VSCode data preview with CLI exec, and a tRPC router for Turso DB lifecycle and SELECT queries.
> 
> - **Backend/Server**:
>   - **Vulnerable Demo**: Adds `row_004_vuln.ts` Express app with hardcoded secrets, insecure MySQL connection, SQL injection (`/user/:id`), XSS (`/comment`), unsafe `eval`, command exec (`/exec`), and unvalidated file read (`/readfile`).
>   - **Nodes Controller**: Introduces `row_025_index.ts` with handlers `getAllNodes`, `getNodeByName`, `getNodesByCategory`, `getSingleNodeIcon`, `getSingleNodeAsyncOptions`, and `executeCustomFunction` using `nodesService` and workspace search options.
> - **Utilities**:
>   - **Suppressions Loader**: Adds `row_017_suppressions.ts` to discover `suppressions.yaml`, parse/validate via `zod`, filter by tool/path using `minimatch`, and evaluate optional `if` via `vm`.
> - **Editor Extension**:
>   - **VSCode Preview**: Adds `row_037_preview.ts` to compile Kusion stacks via `child_process.exec` and render YAML with `shiki` in a webview.
> - **API**:
>   - **tRPC Router**: Adds `row_040_trpc.ts` defining `createDb`, `deleteDb`, and `selectDb` (SELECT-only) using Turso CLI (`exec`) and `@libsql/client`, with basic profanity and name validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2764e0e459768959d86cfdad1244c888415e0fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->