### PR TITLE
Add Typescript Files from typescript_os-command-injection-annotated - Batch 04

### DIFF
--- a/row_001_release.ts
+++ b/row_001_release.ts
@@ -1,0 +1,150 @@
+/* eslint-disable  import/no-extraneous-dependencies,@typescript-eslint/camelcase, no-console */
+import inquirer from 'inquirer';
+import fs from 'fs';
+import path from 'path';
+import child_process from 'child_process';
+import util from 'util';
+import chalk from 'chalk';
+import semverInc from 'semver/functions/inc';
+import { ReleaseType } from 'semver';
+
+import pkg from '../package.json';
+// {fact rule=os-command-injection@v1.0 defects=1}
+
+const exec = util.promisify(child_process.exec);
+
+const run = async (command: string) => {
+  console.log(chalk.green(command));
+// defect
+  await exec(command);
+};
+
+const currentVersion = pkg.version;
+
+const getNextVersions = (): { [key in ReleaseType]: string | null } => ({
+// {/fact}
+  major: semverInc(currentVersion, 'major'),
+  minor: semverInc(currentVersion, 'minor'),
+  patch: semverInc(currentVersion, 'patch'),
+  premajor: semverInc(currentVersion, 'premajor'),
+  preminor: semverInc(currentVersion, 'preminor'),
+  prepatch: semverInc(currentVersion, 'prepatch'),
+  prerelease: semverInc(currentVersion, 'prerelease'),
+});
+
+const timeLog = (logInfo: string, type: 'start' | 'end') => {
+  let info = '';
+  if (type === 'start') {
+    info = `=> 开始任务：${logInfo}`;
+  } else {
+    info = `✨ 结束任务：${logInfo}`;
+  }
+  const nowDate = new Date();
+  console.log(
+    `[${nowDate.toLocaleString()}.${nowDate.getMilliseconds().toString().padStart(3, '0')}] ${info}
+    `,
+  );
+};
+
+/**
+ * 询问获取下一次版本号
+ */
+async function prompt(): Promise<string> {
+  const nextVersions = getNextVersions();
+  const { nextVersion } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'nextVersion',
+      message: `请选择将要发布的版本 (当前版本 ${currentVersion})`,
+      choices: (Object.keys(nextVersions) as Array<ReleaseType>).map((level) => ({
+        name: `${level} => ${nextVersions[level]}`,
+        value: nextVersions[level],
+      })),
+    },
+  ]);
+  return nextVersion;
+}
+
+/**
+ * 更新版本号
+ * @param nextVersion 新版本号
+ */
+async function updateVersion(nextVersion: string) {
+  pkg.version = nextVersion;
+  timeLog('修改package.json版本号', 'start');
+  await fs.writeFileSync(path.resolve(__dirname, './../package.json'), JSON.stringify(pkg));
+  await run('npx prettier package.json --write');
+  timeLog('修改package.json版本号', 'end');
+}
+
+/**
+ * 生成CHANGELOG
+ */
+async function generateChangelog() {
+  timeLog('生成CHANGELOG.md', 'start');
+  await run(' npx conventional-changelog -p angular -i CHANGELOG.md -s -r 0');
+  timeLog('生成CHANGELOG.md', 'end');
+}
+
+/**
+ * 将代码提交至git
+ */
+async function push(nextVersion: string) {
+  timeLog('推送代码至git仓库', 'start');
+  await run('git add package.json CHANGELOG.md');
+  await run(`git commit -m "v${nextVersion}" -n`);
+  await run('git push');
+  timeLog('推送代码至git仓库', 'end');
+}
+
+/**
+ * 组件库打包
+ */
+async function build() {
+  timeLog('组件库打包', 'start');
+  await run('npm run build');
+  timeLog('组件库打包', 'end');
+}
+
+/**
+ * 发布至npm
+ */
+async function publish() {
+  timeLog('发布组件库', 'start');
+  await run('npm publish');
+  timeLog('发布组件库', 'end');
+}
+
+/**
+ * 打tag提交至git
+ */
+async function tag(nextVersion: string) {
+  timeLog('打tag并推送至git', 'start');
+  await run(`git tag v${nextVersion}`);
+  await run(`git push origin tag v${nextVersion}`);
+  timeLog('打tag并推送至git', 'end');
+}
+
+async function main() {
+  try {
+    const nextVersion = await prompt();
+    const startTime = Date.now();
+    // =================== 更新版本号 ===================
+    await updateVersion(nextVersion);
+    // =================== 更新changelog ===================
+    await generateChangelog();
+    // =================== 代码推送git仓库 ===================
+    await push(nextVersion);
+    // =================== 组件库打包 ===================
+    await build();
+    // =================== 发布至npm ===================
+    await publish();
+    // =================== 打tag并推送至git ===================
+    await tag(nextVersion);
+    console.log(`✨ 发布流程结束 共耗时${((Date.now() - startTime) / 1000).toFixed(3)}s`);
+  } catch (error) {
+    console.log('💣 发布失败，失败原因：', error);
+  }
+}
+
+main();

--- a/row_008_http.ts
+++ b/row_008_http.ts
@@ -1,0 +1,503 @@
+import { createServer, IncomingMessage, OutgoingHttpHeaders, Server, ServerResponse } from "http";
+
+export enum HttpStatus {
+	CONTINUE = 100,
+	SWITCHING_PROTOCOLS = 101,
+	PROCESSING = 102,
+	OK = 200,
+	CREATED = 201,
+	ACCEPTED = 202,
+	NON_AUTHORITATIVE_INFORMATION = 203,
+	NO_CONTENT = 204,
+	RESET_CONTENT = 205,
+	PARTIAL_CONTENT = 206,
+	AMBIGUOUS = 300,
+	MOVED_PERMANENTLY = 301,
+	FOUND = 302,
+	SEE_OTHER = 303,
+	NOT_MODIFIED = 304,
+	TEMPORARY_REDIRECT = 307,
+	PERMANENT_REDIRECT = 308,
+	BAD_REQUEST = 400,
+	UNAUTHORIZED = 401,
+	PAYMENT_REQUIRED = 402,
+	FORBIDDEN = 403,
+	NOT_FOUND = 404,
+	METHOD_NOT_ALLOWED = 405,
+	NOT_ACCEPTABLE = 406,
+	PROXY_AUTHENTICATION_REQUIRED = 407,
+	REQUEST_TIMEOUT = 408,
+	CONFLICT = 409,
+	GONE = 410,
+	LENGTH_REQUIRED = 411,
+	PRECONDITION_FAILED = 412,
+	PAYLOAD_TOO_LARGE = 413,
+	URI_TOO_LONG = 414,
+	UNSUPPORTED_MEDIA_TYPE = 415,
+	REQUESTED_RANGE_NOT_SATISFIABLE = 416,
+	EXPECTATION_FAILED = 417,
+	I_AM_A_TEAPOT = 418,
+	UNPROCESSABLE_ENTITY = 422,
+	TOO_MANY_REQUESTS = 429,
+	INTERNAL_SERVER_ERROR = 500,
+	NOT_IMPLEMENTED = 501,
+	BAD_GATEWAY = 502,
+	SERVICE_UNAVAILABLE = 503,
+	GATEWAY_TIMEOUT = 504,
+	HTTP_VERSION_NOT_SUPPORTED = 505,
+}
+export interface IResponse extends ServerResponse {
+	body: any;
+}
+export interface IApp {
+	server?: Server;
+	routes: IRoute[];
+	base?: string;
+	next: boolean;
+	logs?: boolean;
+	middleware: any[];
+	resources: any[];
+	instances: any[];
+	headers: OutgoingHttpHeaders;
+}
+export interface IParam {
+	index?: number;
+	name?: string;
+	fn: (req?: IRequest) => void;
+}
+export interface IRoute {
+	method: HttpMethodsEnum;
+	path: string;
+	name: string;
+	middleware: any[];
+	params: IParam[];
+	fn: any;
+	httpStatus: HttpStatus;
+	headers: OutgoingHttpHeaders;
+}
+export interface IRequest extends IncomingMessage {
+	query: any;
+	body: any;
+	payload: any;
+	params: any;
+	parsed: URL;
+	files: any;
+	next: any;
+	route: IRoute;
+	response: IResponse;
+	request: IRequest;
+	context: {
+		status: HttpStatus,
+		req: IRequest,
+		res: IResponse,
+		headers: any,
+		params: any,
+		[key: string]: any;
+	};
+}
+export interface IOptions {
+	port: number | string;
+	middleware?: any[];
+	base?: string;
+	logs?: boolean;
+	resources?: any[];
+}
+
+export interface IContext {
+	req: IRequest;
+	res: IResponse;
+	headers?: OutgoingHttpHeaders;
+	status?: HttpStatus;
+	redirect?: string;
+	[key: string]: any;
+}
+
+export interface IException {
+	message?: string;
+	error?: any;
+	statusCode?: number;
+}
+
+export type INext = (data?: object) => void;
+
+export enum HttpMethodsEnum {
+	GET = "GET",
+	POST = "POST",
+	PUT = "PUT",
+	DELETE = "DELETE",
+	PATCH = "PATCH",
+	MIXED = "MIXED",
+	HEAD = "HEAD",
+	OPTIONS = "OPTIONS",
+}
+export enum Constants {
+	INVALID_ROUTE = "Invalid route",
+	NO_RESPONSE = "No response",
+	ROUTE_DATA = "__route_data__",
+	ROUTE_MIDDLEWARE = "__route_middleware__",
+	ROUTE_PARAMS = "__route_params__",
+}
+
+export const app: IApp = {
+	headers: {
+		"Content-type": "application/json",
+	},
+	base: "http://via.local",
+	middleware: [],
+	next: false,
+	logs: false,
+	routes: [],
+	resources: [],
+	instances: [],
+};
+
+const decorators: any = {
+	route: [],
+	param: [],
+	middleware: [],
+};
+
+export const bootstrap = (options: IOptions) => {
+	if (options.middleware) {
+		app.middleware = options.middleware;
+	}
+
+	if (options.resources) {
+		app.resources = options.resources;
+	}
+
+	if (options.base) {
+		app.base = options.base;
+	}
+
+	if (options.logs) {
+		app.logs = options.logs;
+	}
+
+	app.server = createServer(onRequest).listen(options.port);
+};
+/**
+ * Convert path to regex
+ * @param str string
+ * @returns new RegExp
+ */
+const regexify = (str: string) => {
+	const parts = str.split("/");
+	parts.shift();
+	const pattern = parts.map((part) => {
+		if (part.startsWith("*")) {
+			return `/(.*)`;
+		} else if (part.startsWith(":")) {
+			if (part.endsWith("?")) {
+				return `(?:/([^/]+?))?`;
+			}
+
+			return `/([^/]+?)`;
+		}
+		return `/${part}`;
+	});
+
+	return {
+		pattern: new RegExp(`^${pattern.join("")}/?$`, "i"),
+	};
+};
+
+/**
+ * Resource decorator
+ * @param path route path
+ */
+export const Resource = (path: string = "", options?: { version: string }) => {
+	return (target: any) => {
+		const resource_before: any[] = [];
+		const resource = decorators.middleware.find((m: any) => m.resource && m.target === target);
+
+		if (resource && resource.middleware) {
+			resource_before.push(...resource.middleware); // = middleware.concat(resource.middleware);
+		}
+		const routes = decorators.route.filter((route: any) => route.target === target);
+		app.routes = app.routes.concat(routes.map((route: any) => {
+			const func = decorators.middleware.find((m: any) => m.descriptor && m.descriptor.value === route.descriptor.value && m.target === route.target);
+			const params = decorators.param.filter((m: any) => route.name === m.name && m.target === route.target);
+			const route_before = [];
+			if (func && func.middleware) {
+				route_before.push(...func.middleware); // = middleware.concat(func.middleware);
+			}
+
+			if (!app.instances[route.target]) {
+				app.instances[route.target] = new route.target();
+			}
+
+			return {
+				target: route.target,
+				fn: route.descriptor.value.bind(app.instances[route.target]),
+				path: options && options.version ? "/" + options.version + path + route.path : path + route.path,
+				middleware: resource_before.concat(route_before),
+				params,
+				name: route.name,
+				method: route.method,
+			};
+		}));
+	};
+};
+
+// Decorators
+export const Before = (...middleware: any[]) => {
+	return (target: any, name?: string, descriptor?: PropertyDescriptor) => {
+		decorators.middleware.push({ middleware, resource: descriptor ? false : true, descriptor, target: descriptor ? target.constructor : target });
+	};
+};
+
+/**
+ * @Route Decorator
+ * @param method HttpMethodsEnum
+ * @param path Route path
+ */
+export const Route = (method: HttpMethodsEnum, path: string, middleware?: any[]) =>
+	(target: object, name: string, descriptor: PropertyDescriptor) => {
+		decorators.route.push({ method, path, name, middleware, descriptor, target: target.constructor });
+	};
+
+export const Params = (fn: any) => (target: object, name: string, index: number) => decorators.param.push({ index, name, fn, target: target.constructor });
+
+export const Get = (path: string) => Route(HttpMethodsEnum.GET, path);
+
+export const Post = (path: string) => Route(HttpMethodsEnum.POST, path);
+
+export const Put = (path: string) => Route(HttpMethodsEnum.PUT, path);
+
+export const Patch = (path: string) => Route(HttpMethodsEnum.PATCH, path);
+
+export const Delete = (path: string) => Route(HttpMethodsEnum.DELETE, path);
+
+export const Mixed = (path: string) => Route(HttpMethodsEnum.MIXED, path);
+
+export const Head = (path: string) => Route(HttpMethodsEnum.HEAD, path);
+
+export const Options = (path: string) => Route(HttpMethodsEnum.OPTIONS, path);
+
+export const Context = (key?: string) => Params((req: IRequest) => !key ? req.context : req.context[key]);
+
+/**
+ * Request handler
+ * @param req Request
+ * @param res Response
+ */
+const onRequest = async (req: IRequest, res: IResponse) => {
+	try {
+		req.params = {};
+		req.parsed = new URL(req.url, app.base);
+		app.next = true;
+		req.route = getRoute(req);
+		req.params = decodeValues(req.params);
+		req.query = decodeValues(Object.fromEntries(req.parsed.searchParams));
+		req.context = {
+			status: HttpStatus.OK,
+			headers: app.headers,
+			params: req.params,
+			route: req.route,
+			query: req.query,
+			req,
+			res,
+		};
+
+		if (app.middleware.length > 0) {
+			await execute(app.middleware, req.context);
+		}
+
+		if (!req.route) {
+			throw new HttpException(Constants.INVALID_ROUTE, HttpStatus.NOT_FOUND);
+		}
+		if (req.route.middleware && app.next) {
+			await execute(req.route.middleware, req.context);
+		}
+
+		if (!app.next) {
+			return;
+		}
+
+		req.context.res.body = await req.route.fn(...args(req));
+
+		resolve(req.context);
+
+	} catch (e) {
+		if (app.logs) {
+			console.error(e);
+		}
+		res.writeHead(e.status || HttpStatus.INTERNAL_SERVER_ERROR, { ...app.headers, ...e.headers });
+		res.write(JSON.stringify({
+			message: e.message,
+			statusCode: e.status,
+		}));
+		res.end();
+	}
+};
+
+/**
+ * Run middleware
+ * @param list
+ * @param context
+ */
+const execute = async (list: any[], context: IContext) => {
+	for (const fn of list) {
+		app.next = false;
+		if (fn instanceof Function) {
+			const result = await fn(context);
+			if (!result) {
+				break;
+			}
+			app.next = true;
+		}
+	}
+};
+
+/**
+ * Find route and match params
+ * @param req Request
+ */
+const getRoute = (req: IRequest) => {
+	return app.routes.find((route) => {
+		const { pathname } = new URL(req.url, app.base);
+// {fact rule=os-command-injection@v1.0 defects=0}
+		const keys = [];
+		const regex = /:([^\/?]+)\??/g;
+
+		route.path = route.path.endsWith("/") && route.path.length > 1 ? route.path.slice(0, -1) : route.path;
+
+// defect
+		let params = regex.exec(route.path);
+		while (params !== null) {
+			keys.push(params[1]);
+			params = regex.exec(route.path);
+		}
+
+// {/fact}
+		const path = route.path.replace(/\/{1,}/g, "/");
+		const { pattern } = regexify(path);
+		const matches = pathname.match(pattern);
+		if (matches && (route.method === req.method
+			|| route.method === HttpMethodsEnum.MIXED)) {
+
+			req.params = Object.assign(req.params, keys.reduce((val: any, key, index) => {
+				val[key] = matches[index + 1];
+				return val;
+			}, {}));
+
+			return true;
+		}
+	});
+};
+
+const args = (req: IRequest) => {
+	const ARGS = [];
+	if (req.route.params) {
+		req.route.params.sort((a, b) => a.index - b.index);
+		for (const param of req.route.params) {
+			ARGS.push(param ? param.fn(req) : undefined);
+		}
+	}
+	return ARGS;
+};
+
+/**
+ * Decode values
+ * @param obj parameter values
+ */
+const decodeValues = (obj: any) => {
+	/*const decoded: { [x: string]: number | boolean | string } = {};
+	for (const key of Object.keys(obj)) {
+		decoded[key] = !isNaN(parseFloat(obj[key])) && isFinite(obj[key]) && !(Number.isSafeInteger(obj[key])) ?
+			(Number.isInteger(obj[key]) ? Number.parseInt(obj[key], 10) :
+				Number.parseFloat(obj[key])) : obj[key];
+	}
+	return decoded;*/
+	const decodedValues: { [key: string]: number | boolean | string } = {};
+
+	for (const key of Object.keys(obj)) {
+		const value = obj[key];
+
+		// Check if the value is a number
+		const isNumeric = !isNaN(parseFloat(value)) && isFinite(value);
+
+		if (isNumeric) {
+			// Parse the number based on its type
+			if (!Number.isSafeInteger(Number(value))) {
+				decodedValues[key] = value.toString();
+			} else if (Number.isInteger(value)) {
+				decodedValues[key] = Number.parseInt(value, 10);
+			} else {
+				decodedValues[key] = Number.parseFloat(value);
+			}
+		} else {
+			// Keep the original value if it's not a number
+			decodedValues[key] = value;
+		}
+	}
+
+	return decodedValues;
+};
+/**
+ * Check if obj is stream
+ * @param obj any
+ */
+const isStream = (obj: any) =>
+	obj &&
+	typeof obj === "object" &&
+	typeof obj.pipe === "function";
+/**
+ * Check if obj is object
+ * @param obj any
+ */
+const isObject = (obj: any) =>
+	obj &&
+	typeof obj === "object" && !Buffer.isBuffer(obj);
+
+/**
+ * Check if obj is readable
+ * @param obj any
+ */
+const isReadable = (obj: any) =>
+	isStream(obj) &&
+	typeof obj._read === "function" &&
+	typeof obj._readableState === "object" || obj.readable;
+
+/**
+ * Resolve request
+ * @param context request context
+ */
+const resolve = (context: IContext) => {
+	if (context.redirect) {
+		context.res.writeHead(context.status,
+			{ Location: context.redirect },
+		);
+		return context.res.end();
+	}
+	context.res.writeHead(context.status, Object.assign({}, app.headers, context.headers));
+	if (isReadable(context.res.body)) {
+		return context.res.body.pipe(context.res);
+	}
+
+	if (isObject(context.res.body)) {
+		return context.res.end(JSON.stringify(context.res.body));
+	}
+
+	context.res.end(context.res.body || "");
+};
+
+export class CustomErrorHandler extends Error {
+	public headers?: OutgoingHttpHeaders;
+}
+/**
+ * HttpException error
+ */
+export class HttpException extends CustomErrorHandler {
+	constructor(message: string, public status: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR, headers?: OutgoingHttpHeaders) {
+		super(message);
+		this.name = this.constructor.name;
+		Error.captureStackTrace(this, this.constructor);
+		this.status = status;
+
+		if (headers) {
+			this.headers = headers;
+		}
+	}
+}

--- a/row_019_node-spec.ts
+++ b/row_019_node-spec.ts
@@ -1,0 +1,1036 @@
+import { webContents } from 'electron/main';
+
+import { expect } from 'chai';
+
+import * as childProcess from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { EventEmitter } from 'node:stream';
+import * as util from 'node:util';
+
+import { copyMacOSFixtureApp, getCodesignIdentity, shouldRunCodesignTests, signApp, spawn } from './lib/codesign-helpers';
+import { withTempDirectory } from './lib/fs-helpers';
+import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
+
+const mainFixturesPath = path.resolve(__dirname, 'fixtures');
+
+describe('node feature', () => {
+  const fixtures = path.join(__dirname, 'fixtures');
+
+  describe('child_process', () => {
+    describe('child_process.fork', () => {
+      it('Works in browser process', async () => {
+        const child = childProcess.fork(path.join(fixtures, 'module', 'ping.js'));
+        const message = once(child, 'message');
+        child.send('message');
+        const [msg] = await message;
+        expect(msg).to.equal('message');
+      });
+
+      it('Has its module searth paths restricted', async () => {
+        const child = childProcess.fork(path.join(fixtures, 'module', 'module-paths.js'));
+        const [msg] = await once(child, 'message');
+        expect(msg.length).to.equal(2);
+      });
+    });
+  });
+
+  describe('child_process in renderer', () => {
+    useRemoteContext();
+
+    describe('child_process.fork', () => {
+      itremote('works in current process', async (fixtures: string) => {
+        const child = require('node:child_process').fork(require('node:path').join(fixtures, 'module', 'ping.js'));
+        const message = new Promise<any>(resolve => child.once('message', resolve));
+        child.send('message');
+        const msg = await message;
+        expect(msg).to.equal('message');
+      }, [fixtures]);
+
+      itremote('preserves args', async (fixtures: string) => {
+        const args = ['--expose_gc', '-test', '1'];
+        const child = require('node:child_process').fork(require('node:path').join(fixtures, 'module', 'process_args.js'), args);
+        const message = new Promise<any>(resolve => child.once('message', resolve));
+        child.send('message');
+        const msg = await message;
+        expect(args).to.deep.equal(msg.slice(2));
+      }, [fixtures]);
+
+      itremote('works in forked process', async (fixtures: string) => {
+        const child = require('node:child_process').fork(require('node:path').join(fixtures, 'module', 'fork_ping.js'));
+        const message = new Promise<any>(resolve => child.once('message', resolve));
+        child.send('message');
+        const msg = await message;
+        expect(msg).to.equal('message');
+      }, [fixtures]);
+
+      itremote('works in forked process when options.env is specified', async (fixtures: string) => {
+        const child = require('node:child_process').fork(require('node:path').join(fixtures, 'module', 'fork_ping.js'), [], {
+          path: process.env.PATH
+        });
+        const message = new Promise<any>(resolve => child.once('message', resolve));
+        child.send('message');
+        const msg = await message;
+        expect(msg).to.equal('message');
+      }, [fixtures]);
+
+      itremote('has String::localeCompare working in script', async (fixtures: string) => {
+        const child = require('node:child_process').fork(require('node:path').join(fixtures, 'module', 'locale-compare.js'));
+        const message = new Promise<any>(resolve => child.once('message', resolve));
+        child.send('message');
+        const msg = await message;
+        expect(msg).to.deep.equal([0, -1, 1]);
+      }, [fixtures]);
+
+      itremote('has setImmediate working in script', async (fixtures: string) => {
+        const child = require('node:child_process').fork(require('node:path').join(fixtures, 'module', 'set-immediate.js'));
+        const message = new Promise<any>(resolve => child.once('message', resolve));
+        child.send('message');
+        const msg = await message;
+        expect(msg).to.equal('ok');
+      }, [fixtures]);
+
+      itremote('pipes stdio', async (fixtures: string) => {
+        const child = require('node:child_process').fork(require('node:path').join(fixtures, 'module', 'process-stdout.js'), { silent: true });
+        let data = '';
+        child.stdout.on('data', (chunk: any) => {
+          data += String(chunk);
+        });
+        const code = await new Promise<any>(resolve => child.once('close', resolve));
+        expect(code).to.equal(0);
+        expect(data).to.equal('pipes stdio');
+      }, [fixtures]);
+
+      itremote('works when sending a message to a process forked with the --eval argument', async () => {
+        const source = "process.on('message', (message) => { process.send(message) })";
+        const forked = require('node:child_process').fork('--eval', [source]);
+        const message = new Promise(resolve => forked.once('message', resolve));
+        forked.send('hello');
+        const msg = await message;
+        expect(msg).to.equal('hello');
+      });
+
+      it('has the electron version in process.versions', async () => {
+        const source = 'process.send(process.versions)';
+        const forked = require('node:child_process').fork('--eval', [source]);
+        const [message] = await once(forked, 'message');
+        expect(message)
+          .to.have.own.property('electron')
+          .that.is.a('string')
+          .and.matches(/^\d+\.\d+\.\d+(\S*)?$/);
+      });
+    });
+
+    describe('child_process.spawn', () => {
+      itremote('supports spawning Electron as a node process via the ELECTRON_RUN_AS_NODE env var', async (fixtures: string) => {
+        const child = require('node:child_process').spawn(process.execPath, [require('node:path').join(fixtures, 'module', 'run-as-node.js')], {
+          env: {
+            ELECTRON_RUN_AS_NODE: true
+          }
+        });
+
+        let output = '';
+        child.stdout.on('data', (data: any) => {
+          output += data;
+        });
+        try {
+          await new Promise(resolve => child.stdout.once('close', resolve));
+          expect(JSON.parse(output)).to.deep.equal({
+            stdoutType: 'pipe',
+            processType: 'undefined',
+            window: 'undefined'
+          });
+        } finally {
+          child.kill();
+        }
+      }, [fixtures]);
+    });
+
+    describe('child_process.exec', () => {
+      ifit(process.platform === 'linux')('allows executing a setuid binary from non-sandboxed renderer', async () => {
+        // Chrome uses prctl(2) to set the NO_NEW_PRIVILEGES flag on Linux (see
+        // https://github.com/torvalds/linux/blob/40fde647cc/Documentation/userspace-api/no_new_privs.rst).
+        // We disable this for unsandboxed processes, which the renderer tests
+        // are running in. If this test fails with an error like 'effective uid
+        // is not 0', then it's likely that our patch to prevent the flag from
+        // being set has become ineffective.
+        const w = await getRemoteContext();
+        const stdout = await w.webContents.executeJavaScript('require(\'child_process\').execSync(\'sudo --help\')');
+        expect(stdout).to.not.be.empty();
+      });
+    });
+  });
+
+  describe('EventSource', () => {
+    itremote('works correctly when nodeIntegration is enabled in the renderer', () => {
+      const es = new EventSource('https://example.com');
+      expect(es).to.have.property('url').that.is.a('string');
+      expect(es).to.have.property('readyState').that.is.a('number');
+      expect(es).to.have.property('withCredentials').that.is.a('boolean');
+    });
+  });
+
+  describe('fetch', () => {
+    itremote('works correctly when nodeIntegration is enabled in the renderer', async (fixtures: string) => {
+      const file = require('node:path').join(fixtures, 'hello.txt');
+      expect(() => {
+        fetch('file://' + file);
+      }).to.not.throw();
+
+      expect(() => {
+        const formData = new FormData();
+        formData.append('username', 'Groucho');
+      }).not.to.throw();
+
+      expect(() => {
+        const request = new Request('https://example.com', {
+          method: 'POST',
+          body: JSON.stringify({ foo: 'bar' })
+        });
+        expect(request.method).to.equal('POST');
+      }).not.to.throw();
+
+      expect(() => {
+        const response = new Response('Hello, world!');
+        expect(response.status).to.equal(200);
+      }).not.to.throw();
+
+      expect(() => {
+        const headers = new Headers();
+        headers.append('Content-Type', 'text/xml');
+      }).not.to.throw();
+    }, [fixtures]);
+  });
+
+  it('does not hang when using the fs module in the renderer process', async () => {
+    const appPath = path.join(mainFixturesPath, 'apps', 'libuv-hang', 'main.js');
+    const appProcess = childProcess.spawn(process.execPath, [appPath], {
+      cwd: path.join(mainFixturesPath, 'apps', 'libuv-hang'),
+      stdio: 'inherit'
+    });
+    const [code] = await once(appProcess, 'close');
+    expect(code).to.equal(0);
+  });
+
+  describe('contexts', () => {
+    describe('setTimeout called under Chromium event loop in browser process', () => {
+      it('Can be scheduled in time', (done) => {
+        setTimeout(done, 0);
+      });
+
+      it('Can be promisified', (done) => {
+        util.promisify(setTimeout)(0).then(done);
+      });
+    });
+
+    describe('setInterval called under Chromium event loop in browser process', () => {
+      it('can be scheduled in time', (done) => {
+        let interval: any = null;
+        let clearing = false;
+        const clear = () => {
+          if (interval === null || clearing) return;
+
+          // interval might trigger while clearing (remote is slow sometimes)
+          clearing = true;
+          clearInterval(interval);
+          clearing = false;
+          interval = null;
+          done();
+        };
+        interval = setInterval(clear, 10);
+      });
+    });
+
+    const suspendListeners = (emitter: EventEmitter, eventName: string, callback: (...args: any[]) => void) => {
+      const listeners = emitter.listeners(eventName) as ((...args: any[]) => void)[];
+      emitter.removeAllListeners(eventName);
+      emitter.once(eventName, (...args) => {
+        emitter.removeAllListeners(eventName);
+        for (const listener of listeners) {
+          emitter.on(eventName, listener);
+        }
+
+        callback(...args);
+      });
+    };
+    describe('error thrown in main process node context', () => {
+      it('gets emitted as a process uncaughtException event', async () => {
+        fs.readFile(__filename, () => {
+          throw new Error('hello');
+        });
+        const result = await new Promise(resolve => suspendListeners(process, 'uncaughtException', (error) => {
+          resolve(error.message);
+        }));
+        expect(result).to.equal('hello');
+      });
+    });
+
+    describe('promise rejection in main process node context', () => {
+      it('gets emitted as a process unhandledRejection event', async () => {
+        fs.readFile(__filename, () => {
+          Promise.reject(new Error('hello'));
+        });
+        const result = await new Promise(resolve => suspendListeners(process, 'unhandledRejection', (error) => {
+          resolve(error.message);
+        }));
+        expect(result).to.equal('hello');
+      });
+
+      it('does not log the warning more than once when the rejection is unhandled', async () => {
+        const appPath = path.join(mainFixturesPath, 'api', 'unhandled-rejection.js');
+        const appProcess = childProcess.spawn(process.execPath, [appPath]);
+
+        let output = '';
+        const out = (data: string) => {
+          output += data;
+          if (/UnhandledPromiseRejectionWarning/.test(data)) {
+            appProcess.kill();
+          }
+        };
+        appProcess.stdout!.on('data', out);
+        appProcess.stderr!.on('data', out);
+
+        await once(appProcess, 'exit');
+        expect(/UnhandledPromiseRejectionWarning/.test(output)).to.equal(true);
+        const matches = output.match(/Error: oops/gm);
+        expect(matches).to.have.lengthOf(1);
+      });
+
+      it('does not log the warning more than once when the rejection is handled', async () => {
+        const appPath = path.join(mainFixturesPath, 'api', 'unhandled-rejection-handled.js');
+        const appProcess = childProcess.spawn(process.execPath, [appPath]);
+
+        let output = '';
+        const out = (data: string) => { output += data; };
+        appProcess.stdout!.on('data', out);
+        appProcess.stderr!.on('data', out);
+
+        const [code] = await once(appProcess, 'exit');
+        expect(code).to.equal(0);
+        expect(/UnhandledPromiseRejectionWarning/.test(output)).to.equal(false);
+        const matches = output.match(/Error: oops/gm);
+        expect(matches).to.have.lengthOf(1);
+      });
+    });
+  });
+
+  describe('contexts in renderer', () => {
+    useRemoteContext();
+
+    describe('setTimeout in fs callback', () => {
+      itremote('does not crash', async (filename: string) => {
+        await new Promise(resolve => require('node:fs').readFile(filename, () => {
+          setTimeout(resolve, 0);
+        }));
+      }, [__filename]);
+    });
+
+    describe('error thrown in renderer process node context', () => {
+      itremote('gets emitted as a process uncaughtException event', async (filename: string) => {
+        const error = new Error('boo!');
+        require('node:fs').readFile(filename, () => {
+          throw error;
+        });
+        await new Promise<void>((resolve, reject) => {
+          process.once('uncaughtException', (thrown) => {
+            try {
+              expect(thrown).to.equal(error);
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          });
+        });
+      }, [__filename]);
+    });
+
+    describe('URL handling in the renderer process', () => {
+      itremote('can successfully handle WHATWG URLs constructed by Blink', (fixtures: string) => {
+        const url = new URL('file://' + require('node:path').resolve(fixtures, 'pages', 'base-page.html'));
+        expect(() => {
+          require('node:fs').createReadStream(url);
+        }).to.not.throw();
+      }, [fixtures]);
+    });
+
+    describe('setTimeout called under blink env in renderer process', () => {
+      itremote('can be scheduled in time', async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      });
+
+      itremote('works from the timers module', async () => {
+        await new Promise(resolve => require('node:timers').setTimeout(resolve, 10));
+      });
+    });
+
+    describe('setInterval called under blink env in renderer process', () => {
+      itremote('can be scheduled in time', async () => {
+        await new Promise<void>(resolve => {
+          const id = setInterval(() => {
+            clearInterval(id);
+            resolve();
+          }, 10);
+        });
+      });
+
+      itremote('can be scheduled in time from timers module', async () => {
+        const { setInterval, clearInterval } = require('node:timers');
+        await new Promise<void>(resolve => {
+          const id = setInterval(() => {
+            clearInterval(id);
+            resolve();
+          }, 10);
+        });
+      });
+    });
+  });
+
+  describe('message loop in renderer', () => {
+    useRemoteContext();
+
+    describe('process.nextTick', () => {
+      itremote('emits the callback', () => new Promise(resolve => process.nextTick(resolve)));
+
+      itremote('works in nested calls', () =>
+        new Promise(resolve => {
+          process.nextTick(() => {
+            process.nextTick(() => process.nextTick(resolve));
+          });
+        }));
+    });
+
+    describe('setImmediate', () => {
+      itremote('emits the callback', () => new Promise(resolve => setImmediate(resolve)));
+
+      itremote('works in nested calls', () => new Promise(resolve => {
+        setImmediate(() => {
+          setImmediate(() => setImmediate(resolve));
+        });
+      }));
+    });
+  });
+
+  ifdescribe(process.platform === 'darwin')('net.connect', () => {
+    itremote('emit error when connect to a socket path without listeners', async (fixtures: string) => {
+      const socketPath = require('node:path').join(require('node:os').tmpdir(), 'electron-test.sock');
+      const script = require('node:path').join(fixtures, 'module', 'create_socket.js');
+      const child = require('node:child_process').fork(script, [socketPath]);
+      const code = await new Promise(resolve => child.once('exit', resolve));
+      expect(code).to.equal(0);
+      const client = require('node:net').connect(socketPath);
+      const error = await new Promise<any>(resolve => client.once('error', resolve));
+      expect(error.code).to.equal('ECONNREFUSED');
+    }, [fixtures]);
+  });
+
+  describe('Buffer', () => {
+    useRemoteContext();
+
+    itremote('can be created from Blink external string', () => {
+      const p = document.createElement('p');
+      p.innerText = '闲云潭影日悠悠，物换星移几度秋';
+      const b = Buffer.from(p.innerText);
+      expect(b.toString()).to.equal('闲云潭影日悠悠，物换星移几度秋');
+      expect(Buffer.byteLength(p.innerText)).to.equal(45);
+    });
+
+    itremote('correctly parses external one-byte UTF8 string', () => {
+      const p = document.createElement('p');
+      p.innerText = 'Jøhänñéß';
+      const b = Buffer.from(p.innerText);
+      expect(b.toString()).to.equal('Jøhänñéß');
+      expect(Buffer.byteLength(p.innerText)).to.equal(13);
+    });
+
+    itremote('does not crash when creating large Buffers', () => {
+      let buffer = Buffer.from(new Array(4096).join(' '));
+      expect(buffer.length).to.equal(4095);
+      buffer = Buffer.from(new Array(4097).join(' '));
+      expect(buffer.length).to.equal(4096);
+    });
+
+    itremote('does not crash for crypto operations', () => {
+      const crypto = require('node:crypto');
+      const data = 'lG9E+/g4JmRmedDAnihtBD4Dfaha/GFOjd+xUOQI05UtfVX3DjUXvrS98p7kZQwY3LNhdiFo7MY5rGft8yBuDhKuNNag9vRx/44IuClDhdQ=';
+      const key = 'q90K9yBqhWZnAMCMTOJfPQ==';
+      const cipherText = '{"error_code":114,"error_message":"Tham số không hợp lệ","data":null}';
+      for (let i = 0; i < 10000; ++i) {
+        const iv = Buffer.from('0'.repeat(32), 'hex');
+        const input = Buffer.from(data, 'base64');
+        const decipher = crypto.createDecipheriv('aes-128-cbc', Buffer.from(key, 'base64'), iv);
+        const result = Buffer.concat([decipher.update(input), decipher.final()]).toString('utf8');
+        expect(cipherText).to.equal(result);
+      }
+    });
+
+    itremote('does not crash when using crypto.diffieHellman() constructors', () => {
+      const crypto = require('node:crypto');
+
+      crypto.createDiffieHellman('abc');
+      crypto.createDiffieHellman('abc', 2);
+
+      // Needed to test specific DiffieHellman ctors.
+
+      crypto.createDiffieHellman('abc', Buffer.from([2]));
+      crypto.createDiffieHellman('abc', '123');
+    });
+
+    itremote('does not crash when calling crypto.createPrivateKey() with an unsupported algorithm', () => {
+      const crypto = require('node:crypto');
+
+      const ed448 = {
+        crv: 'Ed448',
+        x: 'KYWcaDwgH77xdAwcbzOgvCVcGMy9I6prRQBhQTTdKXUcr-VquTz7Fd5adJO0wT2VHysF3bk3kBoA',
+        d: 'UhC3-vN5vp_g9PnTknXZgfXUez7Xvw-OfuJ0pYkuwzpYkcTvacqoFkV_O05WMHpyXkzH9q2wzx5n',
+        kty: 'OKP'
+      };
+
+      expect(() => {
+        crypto.createPrivateKey({ key: ed448, format: 'jwk' });
+      }).to.throw(/Invalid JWK data/);
+    });
+  });
+
+  describe('process.stdout', () => {
+    useRemoteContext();
+
+    itremote('does not throw an exception when accessed', () => {
+      expect(() => process.stdout).to.not.throw();
+    });
+
+    itremote('does not throw an exception when calling write()', () => {
+      expect(() => {
+        process.stdout.write('test');
+      }).to.not.throw();
+    });
+
+    // TODO: figure out why process.stdout.isTTY is true on Darwin but not Linux/Win.
+    ifdescribe(process.platform !== 'darwin')('isTTY', () => {
+      itremote('should be undefined in the renderer process', function () {
+        expect(process.stdout.isTTY).to.be.undefined();
+      });
+    });
+  });
+
+  describe('process.stdin', () => {
+    useRemoteContext();
+
+    itremote('does not throw an exception when accessed', () => {
+      expect(() => process.stdin).to.not.throw();
+    });
+
+    itremote('returns null when read from', () => {
+      expect(process.stdin.read()).to.be.null();
+    });
+  });
+
+  describe('process.version', () => {
+    itremote('should not have -pre', () => {
+      expect(process.version.endsWith('-pre')).to.be.false();
+    });
+  });
+
+  describe('vm.runInNewContext', () => {
+    itremote('should not crash', () => {
+      require('node:vm').runInNewContext('');
+    });
+  });
+
+  describe('crypto', () => {
+    useRemoteContext();
+    itremote('should list the ripemd160 hash in getHashes', () => {
+      expect(require('node:crypto').getHashes()).to.include('ripemd160');
+    });
+
+    itremote('should be able to create a ripemd160 hash and use it', () => {
+      const hash = require('node:crypto').createHash('ripemd160');
+      hash.update('electron-ripemd160');
+      expect(hash.digest('hex')).to.equal('fa7fec13c624009ab126ebb99eda6525583395fe');
+    });
+
+    itremote('should list aes-{128,256}-cfb in getCiphers', () => {
+      expect(require('node:crypto').getCiphers()).to.include.members(['aes-128-cfb', 'aes-256-cfb']);
+    });
+
+    itremote('should be able to create an aes-128-cfb cipher', () => {
+      require('node:crypto').createCipheriv('aes-128-cfb', '0123456789abcdef', '0123456789abcdef');
+    });
+
+    itremote('should be able to create an aes-256-cfb cipher', () => {
+      require('node:crypto').createCipheriv('aes-256-cfb', '0123456789abcdef0123456789abcdef', '0123456789abcdef');
+    });
+
+    itremote('should be able to create a bf-{cbc,cfb,ecb} ciphers', () => {
+      require('node:crypto').createCipheriv('bf-cbc', Buffer.from('0123456789abcdef'), Buffer.from('01234567'));
+      require('node:crypto').createCipheriv('bf-cfb', Buffer.from('0123456789abcdef'), Buffer.from('01234567'));
+      require('node:crypto').createCipheriv('bf-ecb', Buffer.from('0123456789abcdef'), Buffer.from('01234567'));
+    });
+
+    itremote('should list des-ede-cbc in getCiphers', () => {
+      expect(require('node:crypto').getCiphers()).to.include('des-ede-cbc');
+    });
+
+    itremote('should be able to create an des-ede-cbc cipher', () => {
+      const key = Buffer.from('0123456789abcdeff1e0d3c2b5a49786', 'hex');
+      const iv = Buffer.from('fedcba9876543210', 'hex');
+      require('node:crypto').createCipheriv('des-ede-cbc', key, iv);
+    });
+
+    itremote('should not crash when getting an ECDH key', () => {
+      const ecdh = require('node:crypto').createECDH('prime256v1');
+      expect(ecdh.generateKeys()).to.be.an.instanceof(Buffer);
+      expect(ecdh.getPrivateKey()).to.be.an.instanceof(Buffer);
+    });
+
+    itremote('should not crash when generating DH keys or fetching DH fields', () => {
+      const dh = require('node:crypto').createDiffieHellman('modp15');
+      expect(dh.generateKeys()).to.be.an.instanceof(Buffer);
+      expect(dh.getPublicKey()).to.be.an.instanceof(Buffer);
+      expect(dh.getPrivateKey()).to.be.an.instanceof(Buffer);
+      expect(dh.getPrime()).to.be.an.instanceof(Buffer);
+      expect(dh.getGenerator()).to.be.an.instanceof(Buffer);
+    });
+
+    itremote('should not crash when creating an ECDH cipher', () => {
+      const crypto = require('node:crypto');
+      const dh = crypto.createECDH('prime256v1');
+      dh.generateKeys();
+      dh.setPrivateKey(dh.getPrivateKey());
+    });
+  });
+
+  itremote('includes the electron version in process.versions', () => {
+    expect(process.versions)
+      .to.have.own.property('electron')
+      .that.is.a('string')
+      .and.matches(/^\d+\.\d+\.\d+(\S*)?$/);
+  });
+
+  itremote('includes the chrome version in process.versions', () => {
+    expect(process.versions)
+      .to.have.own.property('chrome')
+      .that.is.a('string')
+      .and.matches(/^\d+\.\d+\.\d+\.\d+$/);
+  });
+
+  describe('NODE_OPTIONS', () => {
+    let child: childProcess.ChildProcessWithoutNullStreams;
+    let exitPromise: Promise<any[]>;
+
+    it('Fails for options disallowed by Node.js itself', (done) => {
+      after(async () => {
+        const [code, signal] = await exitPromise;
+        expect(signal).to.equal(null);
+
+        // Exit code 9 indicates cli flag parsing failure
+        expect(code).to.equal(9);
+        child.kill();
+      });
+
+      const env = { ...process.env, NODE_OPTIONS: '--v8-options' };
+      child = childProcess.spawn(process.execPath, { env });
+      exitPromise = once(child, 'exit');
+
+      let output = '';
+      let success = false;
+      const cleanup = () => {
+        child.stderr.removeListener('data', listener);
+        child.stdout.removeListener('data', listener);
+      };
+
+      const listener = (data: Buffer) => {
+        output += data;
+        if (/electron: --v8-options is not allowed in NODE_OPTIONS/m.test(output)) {
+          success = true;
+          cleanup();
+          done();
+        }
+      };
+
+      child.stderr.on('data', listener);
+      child.stdout.on('data', listener);
+      child.on('exit', () => {
+        if (!success) {
+          cleanup();
+          done(new Error(`Unexpected output: ${output.toString()}`));
+        }
+      });
+    });
+
+    it('Disallows crypto-related options', (done) => {
+      after(() => {
+        child.kill();
+      });
+
+      const appPath = path.join(fixtures, 'module', 'noop.js');
+      const env = { ...process.env, NODE_OPTIONS: '--use-openssl-ca' };
+      child = childProcess.spawn(process.execPath, ['--enable-logging', appPath], { env });
+
+      let output = '';
+      const cleanup = () => {
+        child.stderr.removeListener('data', listener);
+        child.stdout.removeListener('data', listener);
+      };
+
+      const listener = (data: Buffer) => {
+        output += data;
+        if (/The NODE_OPTION --use-openssl-ca is not supported in Electron/m.test(output)) {
+          cleanup();
+          done();
+        }
+      };
+
+      child.stderr.on('data', listener);
+      child.stdout.on('data', listener);
+    });
+
+    it('does allow --require in non-packaged apps', async () => {
+      const appPath = path.join(fixtures, 'module', 'noop.js');
+      const env = {
+        ...process.env,
+        NODE_OPTIONS: `--require=${path.join(fixtures, 'module', 'fail.js')}`
+      };
+      // App should exit with code 1.
+      const child = childProcess.spawn(process.execPath, [appPath], { env });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(1);
+    });
+
+    it('does allow --require in utility process of non-packaged apps', async () => {
+      const appPath = path.join(fixtures, 'apps', 'node-options-utility-process');
+      // App should exit with code 1.
+      const child = childProcess.spawn(process.execPath, [appPath]);
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(1);
+    });
+
+    it('does not allow --require in utility process of packaged apps', async () => {
+      const appPath = path.join(fixtures, 'apps', 'node-options-utility-process');
+      // App should exit with code 1.
+      const child = childProcess.spawn(process.execPath, [appPath], {
+        env: {
+          ...process.env,
+          ELECTRON_FORCE_IS_PACKAGED: 'true'
+        }
+      });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(0);
+    });
+
+    it('does not allow --require in packaged apps', async () => {
+      const appPath = path.join(fixtures, 'module', 'noop.js');
+      const env = {
+        ...process.env,
+        ELECTRON_FORCE_IS_PACKAGED: 'true',
+        NODE_OPTIONS: `--require=${path.join(fixtures, 'module', 'fail.js')}`
+      };
+      // App should exit with code 0.
+      const child = childProcess.spawn(process.execPath, [appPath], { env });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(0);
+    });
+  });
+
+  ifdescribe(shouldRunCodesignTests)('NODE_OPTIONS in signed app', function () {
+    let identity = '';
+
+    beforeEach(function () {
+      const result = getCodesignIdentity();
+      if (result === null) {
+        this.skip();
+      } else {
+        identity = result;
+      }
+    });
+
+    const script = path.join(fixtures, 'api', 'fork-with-node-options.js');
+    const nodeOptionsWarning = 'Node.js environment variables are disabled because this process is invoked by other apps';
+
+    it('is disabled when invoked by other apps in ELECTRON_RUN_AS_NODE mode', async () => {
+      await withTempDirectory(async (dir) => {
+        const appPath = await copyMacOSFixtureApp(dir);
+        await signApp(appPath, identity);
+        // Invoke Electron by using the system node binary as middle layer, so
+        // the check of NODE_OPTIONS will think the process is started by other
+        // apps.
+        const { code, out } = await spawn('node', [script, path.join(appPath, 'Contents/MacOS/Electron')]);
+        expect(code).to.equal(0);
+        expect(out).to.include(nodeOptionsWarning);
+      });
+    });
+
+    it('is disabled when invoked by alien binary in app bundle in ELECTRON_RUN_AS_NODE mode', async function () {
+      await withTempDirectory(async (dir) => {
+        const appPath = await copyMacOSFixtureApp(dir);
+        await signApp(appPath, identity);
+        // Find system node and copy it to app bundle.
+        const nodePath = process.env.PATH?.split(path.delimiter).find(dir => fs.existsSync(path.join(dir, 'node')));
+        if (!nodePath) {
+          this.skip();
+          return;
+        }
+        const alienBinary = path.join(appPath, 'Contents/MacOS/node');
+        await fs.promises.cp(path.join(nodePath, 'node'), alienBinary, { recursive: true });
+        // Try to execute electron app from the alien node in app bundle.
+        const { code, out } = await spawn(alienBinary, [script, path.join(appPath, 'Contents/MacOS/Electron')]);
+        expect(code).to.equal(0);
+        expect(out).to.include(nodeOptionsWarning);
+      });
+    });
+
+    it('is respected when invoked from self', async () => {
+      await withTempDirectory(async (dir) => {
+        const appPath = await copyMacOSFixtureApp(dir, null);
+        await signApp(appPath, identity);
+        const appExePath = path.join(appPath, 'Contents/MacOS/Electron');
+        const { code, out } = await spawn(appExePath, [script, appExePath]);
+        expect(code).to.equal(1);
+        expect(out).to.not.include(nodeOptionsWarning);
+        expect(out).to.include('NODE_OPTIONS passed to child');
+      });
+    });
+  });
+
+  describe('Node.js cli flags', () => {
+    let child: childProcess.ChildProcessWithoutNullStreams;
+    let exitPromise: Promise<any[]>;
+
+    it('Prohibits crypto-related flags in ELECTRON_RUN_AS_NODE mode', (done) => {
+      after(async () => {
+        const [code, signal] = await exitPromise;
+        expect(signal).to.equal(null);
+        expect(code).to.equal(9);
+        child.kill();
+      });
+
+      child = childProcess.spawn(process.execPath, ['--force-fips'], {
+        env: { ELECTRON_RUN_AS_NODE: 'true' }
+      });
+      exitPromise = once(child, 'exit');
+
+      let output = '';
+      const cleanup = () => {
+        child.stderr.removeListener('data', listener);
+        child.stdout.removeListener('data', listener);
+      };
+
+      const listener = (data: Buffer) => {
+        output += data;
+        if (/.*The Node.js cli flag --force-fips is not supported in Electron/m.test(output)) {
+          cleanup();
+          done();
+        }
+      };
+
+      child.stderr.on('data', listener);
+      child.stdout.on('data', listener);
+    });
+  });
+
+  describe('process.stdout', () => {
+    it('is a real Node stream', () => {
+      expect((process.stdout as any)._type).to.not.be.undefined();
+    });
+  });
+
+  describe('fs.readFile', () => {
+    it('can accept a FileHandle as the Path argument', async () => {
+      const filePathForHandle = path.resolve(mainFixturesPath, 'dogs-running.txt');
+      const fileHandle = await fs.promises.open(filePathForHandle, 'r');
+
+      const file = await fs.promises.readFile(fileHandle, { encoding: 'utf8' });
+      expect(file).to.not.be.empty();
+      await fileHandle.close();
+    });
+  });
+
+  describe('inspector', () => {
+    let child: childProcess.ChildProcessWithoutNullStreams;
+    let exitPromise: Promise<any[]> | null;
+
+    afterEach(async () => {
+      if (child && exitPromise) {
+        const [code, signal] = await exitPromise;
+        expect(signal).to.equal(null);
+        expect(code).to.equal(0);
+      } else if (child) {
+        child.kill();
+      }
+      child = null as any;
+      exitPromise = null as any;
+    });
+
+    it('Supports starting the v8 inspector with --inspect/--inspect-brk', (done) => {
+      child = childProcess.spawn(process.execPath, ['--inspect-brk', path.join(fixtures, 'module', 'run-as-node.js')], {
+        env: { ELECTRON_RUN_AS_NODE: 'true' }
+      });
+
+      let output = '';
+      const cleanup = () => {
+        child.stderr.removeListener('data', listener);
+        child.stdout.removeListener('data', listener);
+      };
+
+      const listener = (data: Buffer) => {
+        output += data;
+        if (/Debugger listening on ws:/m.test(output)) {
+          cleanup();
+          done();
+        }
+      };
+
+      child.stderr.on('data', listener);
+      child.stdout.on('data', listener);
+    });
+
+    it('Supports starting the v8 inspector with --inspect and a provided port', async () => {
+      child = childProcess.spawn(process.execPath, ['--inspect=17364', path.join(fixtures, 'module', 'run-as-node.js')], {
+        env: { ELECTRON_RUN_AS_NODE: 'true' }
+      });
+      exitPromise = once(child, 'exit');
+
+      let output = '';
+      const listener = (data: Buffer) => { output += data; };
+      const cleanup = () => {
+        child.stderr.removeListener('data', listener);
+        child.stdout.removeListener('data', listener);
+      };
+
+      child.stderr.on('data', listener);
+      child.stdout.on('data', listener);
+      await once(child, 'exit');
+      cleanup();
+      if (/^Debugger listening on ws:/m.test(output)) {
+        expect(output.trim()).to.contain(':17364', 'should be listening on port 17364');
+      } else {
+        throw new Error(`Unexpected output: ${output.toString()}`);
+      }
+    });
+
+    it('Does not start the v8 inspector when --inspect is after a -- argument', async () => {
+      child = childProcess.spawn(process.execPath, [path.join(fixtures, 'module', 'noop.js'), '--', '--inspect']);
+      exitPromise = once(child, 'exit');
+
+      let output = '';
+      const listener = (data: Buffer) => { output += data; };
+      child.stderr.on('data', listener);
+      child.stdout.on('data', listener);
+      await once(child, 'exit');
+      if (output.trim().startsWith('Debugger listening on ws://')) {
+        throw new Error('Inspector was started when it should not have been');
+      }
+    });
+
+    // IPC Electron child process not supported on Windows.
+    ifit(process.platform !== 'win32')('does not crash when quitting with the inspector connected', function (done) {
+      child = childProcess.spawn(process.execPath, [path.join(fixtures, 'module', 'delay-exit'), '--inspect=0'], {
+        stdio: ['ipc']
+      }) as childProcess.ChildProcessWithoutNullStreams;
+      exitPromise = once(child, 'exit');
+
+      const cleanup = () => {
+        child.stderr.removeListener('data', listener);
+        child.stdout.removeListener('data', listener);
+      };
+
+// {fact rule=os-command-injection@v1.0 defects=0}
+      let output = '';
+      const success = false;
+      function listener (data: Buffer) {
+        output += data;
+        console.log(data.toString()); // NOTE: temporary debug logging to try to catch flake.
+// defect
+        const match = /^Debugger listening on (ws:\/\/.+:\d+\/.+)\n/m.exec(output.trim());
+        if (match) {
+          cleanup();
+          // NOTE: temporary debug logging to try to catch flake.
+          child.stderr.on('data', (m) => console.log(m.toString()));
+          child.stdout.on('data', (m) => console.log(m.toString()));
+// {/fact}
+          const w = (webContents as typeof ElectronInternal.WebContents).create();
+          w.loadURL('about:blank')
+            .then(() => w.executeJavaScript(`new Promise(resolve => {
+              const connection = new WebSocket(${JSON.stringify(match[1])})
+              connection.onopen = () => {
+                connection.onclose = () => resolve()
+                connection.close()
+              }
+            })`))
+            .then(() => {
+              w.destroy();
+              child.send('plz-quit');
+              done();
+            });
+        }
+      }
+
+      child.stderr.on('data', listener);
+      child.stdout.on('data', listener);
+      child.on('exit', () => {
+        if (!success) cleanup();
+      });
+    });
+
+    it('Supports js binding', async () => {
+      child = childProcess.spawn(process.execPath, ['--inspect', path.join(fixtures, 'module', 'inspector-binding.js')], {
+        env: { ELECTRON_RUN_AS_NODE: 'true' },
+        stdio: ['ipc']
+      }) as childProcess.ChildProcessWithoutNullStreams;
+      exitPromise = once(child, 'exit');
+
+      const [{ cmd, debuggerEnabled, success }] = await once(child, 'message');
+      expect(cmd).to.equal('assert');
+      expect(debuggerEnabled).to.be.true();
+      expect(success).to.be.true();
+    });
+  });
+
+  itremote('handles assert module assertions as expected', () => {
+    const assert = require('node:assert');
+    try {
+      assert.ok(false);
+      expect.fail('assert.ok(false) should throw');
+    } catch (err) {
+      console.log(err);
+      expect(err).to.be.instanceOf(assert.AssertionError);
+    }
+  });
+
+  it('Can find a module using a package.json main field', () => {
+    const result = childProcess.spawnSync(process.execPath, [path.resolve(fixtures, 'api', 'electron-main-module', 'app.asar')], { stdio: 'inherit' });
+    expect(result.status).to.equal(0);
+  });
+
+  it('handles Promise timeouts correctly', async () => {
+    const scriptPath = path.join(fixtures, 'module', 'node-promise-timer.js');
+    const child = childProcess.spawn(process.execPath, [scriptPath], {
+      env: { ELECTRON_RUN_AS_NODE: 'true' }
+    });
+    const [code, signal] = await once(child, 'exit');
+    expect(code).to.equal(0);
+    expect(signal).to.equal(null);
+    child.kill();
+  });
+
+  it('performs microtask checkpoint correctly', (done) => {
+    let timer : NodeJS.Timeout;
+    const listener = () => {
+      done(new Error('catch block is delayed to next tick'));
+    };
+
+    const f3 = async () => {
+      return new Promise((resolve, reject) => {
+        timer = setTimeout(listener);
+        reject(new Error('oops'));
+      });
+    };
+
+    setTimeout(() => {
+      f3().catch(() => {
+        clearTimeout(timer);
+        done();
+      });
+    });
+  });
+});

--- a/row_026_build.ts
+++ b/row_026_build.ts
@@ -1,0 +1,34 @@
+import * as child_process from 'child_process'
+import {rm} from 'node:fs/promises'
+import * as path from 'node:path'
+import {promisify} from 'util'
+
+const exec = promisify(child_process.exec)
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+export async function deleteIfExists(dir: string): Promise<void> {
+  return rm(dir, {recursive: true, force: true})
+}
+
+export async function clone(ref: string, dir: string): Promise<void> {
+// defect
+  await exec(`git clone https://github.com/lf-lang/lingua-franca.git ${dir}`)
+  await exec(`git checkout ${ref}`, {cwd: dir})
+  await exec('git submodule update --init', {cwd: dir})
+}
+
+export async function build(dir: string): Promise<void> {
+// {/fact}
+  await exec('./gradlew assemble', {cwd: dir})
+}
+
+export async function gradleStop(dir: string): Promise<void> {
+  await exec('./gradlew --stop', {cwd: dir})
+}
+
+export function configurePath(dir: string): void {
+  process.env.PATH = `${process.env.PATH}:${path.join(
+    path.resolve(dir),
+    'build/install/lf-cli/bin'
+  )}`
+}

--- a/row_040_viteonfig.ts
+++ b/row_040_viteonfig.ts
@@ -1,0 +1,363 @@
+import {
+  defineConfig,
+  mergeConfig,
+  Plugin,
+  searchForWorkspaceRoot,
+  UserConfig,
+  ViteDevServer
+} from 'vite'
+import vue from '@vitejs/plugin-vue'
+import EnvironmentPlugin from 'vite-plugin-environment'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
+import { treatAsCommonjs } from 'vite-plugin-treat-umd-as-commonjs'
+import visualizer from 'rollup-plugin-visualizer'
+import compression from 'rollup-plugin-gzip'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
+
+import { basename, join } from 'path'
+import { existsSync, readdirSync, readFileSync } from 'fs'
+
+// build config
+import packageJson from './package.json'
+import { compilerOptions } from './vite.config.common'
+import { getUserAgentRegex } from 'browserslist-useragent-regexp'
+import browserslistToEsbuild from 'browserslist-to-esbuild'
+import fetch from 'node-fetch'
+import { Agent } from 'https'
+
+// @ts-ignore
+import ejs from 'ejs'
+
+const dist = process.env.DIST_DIR || 'dist'
+
+const buildConfig = {
+  requirejs: {},
+  cdn: process.env.CDN === 'true',
+  documentation_url: process.env.DOCUMENTATION_URL,
+  ...(process.env.REQUIRE_TIMEOUT && {
+    requirejs: { waitSeconds: parseInt(process.env.REQUIRE_TIMEOUT) }
+  })
+}
+
+const projectRootDir = searchForWorkspaceRoot(process.cwd())
+const { version } = packageJson
+const supportedBrowsersRegex = getUserAgentRegex({ allowHigherVersions: true })
+
+const stripScssMarker = '/* STYLES STRIP IMPORTS MARKER */'
+
+// determine inputs
+const input = readdirSync('packages').reduce(
+  (acc, i) => {
+    if (!i.startsWith('web-app')) {
+      return acc
+    }
+    for (const extension of ['js', 'ts']) {
+      const root = join('packages', i, 'src', `index.${extension}`)
+      if (existsSync(root)) {
+        acc[i as keyof typeof acc] = root
+        break
+      }
+    }
+    return acc
+  },
+  {
+    'index.html': 'index.html',
+    'oidc-silent-redirect.html': 'oidc-silent-redirect.html',
+    'oidc-callback.html': 'oidc-callback.html'
+  }
+)
+
+const getJson = async (url: string) => {
+  return (
+    await fetch(url, {
+      ...(url.startsWith('https:') && {
+        agent: new Agent({ rejectUnauthorized: false })
+      })
+    })
+  ).json()
+}
+
+type ConfigJsonResponseBody = {
+  options: Record<string, any>
+}
+
+const getConfigJson = async (url: string) => {
+  return (await getJson(url)) as ConfigJsonResponseBody
+}
+
+export const historyModePlugins = () =>
+  [
+    {
+      name: 'base-href',
+      transformIndexHtml: {
+        handler() {
+          return [
+            {
+              injectTo: 'head-prepend',
+              tag: 'base',
+              attrs: {
+                href: '/'
+              }
+            }
+          ]
+        }
+      }
+    }
+  ] as const
+
+export default defineConfig(({ mode, command }) => {
+  const production = mode === 'production'
+
+  /**
+     When setting `OWNCLOUD_WEB_CONFIG_URL` make sure to configure the oauth/oidc client
+
+
+     # oCIS
+     For oCIS instances you can use `./dev/docker/ocis.idp.config.yaml`.
+     In docker setups you need to mount it to `/etc/ocis/idp.yaml`.
+     E.g. with docker-compose you could add a volume to the ocis container like this:
+     - /home/youruser/projects/oc-web/dev/docker/ocis.idp.config.yaml:/etc/ocis/idp.yaml
+
+     To use the oCIS deployment examples start vite like this:
+     OWNCLOUD_WEB_CONFIG_URL="https://ocis.owncloud.test/config.json" pnpm vite
+
+     */
+  const configUrl =
+    process.env.OWNCLOUD_WEB_CONFIG_URL || 'https://host.docker.internal:9200/config.json'
+
+  const config: UserConfig = {
+    ...(!production && {
+      server: {
+        port: 9201,
+        ...(process.env.VITEST !== 'true' && {
+          https: {
+            key: readFileSync('./dev/docker/traefik/certificates/server.key'),
+            cert: readFileSync('./dev/docker/traefik/certificates/server.crt')
+          },
+          proxy: {
+            '/themes': {
+              target: 'https://host.docker.internal:9200',
+              changeOrigin: true,
+              secure: false // allow self-signed certs
+            }
+          }
+        })
+      }
+    })
+  }
+
+  return mergeConfig(
+    {
+      base: '',
+      publicDir: 'packages/web-container',
+      build: {
+        // TODO: Vue3: We currently cannot inline styles of components because @vite/plugin-vue2 does not support it
+        // c.f. https://github.com/vitejs/vite-plugin-vue2/issues/18
+        // That's why we need to put all styles of our monorepo apps into a monolithic css file for now
+        // Once the above issue is resolved or we switch to @vitejs/plugin-vue, we can remove the `cssCodeSplit` setting here
+        cssCodeSplit: false,
+        rollupOptions: {
+          preserveEntrySignatures: 'strict',
+          input,
+          output: {
+            dir: dist,
+            chunkFileNames: join('js', 'chunks', `[name]-[hash].mjs`),
+            entryFileNames: join('js', '[name]-[hash].mjs')
+          }
+        },
+        target: browserslistToEsbuild()
+      },
+      server: {
+        host: 'host.docker.internal',
+        strictPort: true
+      },
+      css: {
+        preprocessorOptions: {
+          scss: {
+            additionalData: `
+              @use "sass:math";
+              @import "${projectRootDir}/packages/design-system/src/styles/styles";${stripScssMarker}
+            `,
+            silenceDeprecations: ['legacy-js-api', 'import']
+          }
+        }
+      },
+      resolve: {
+        dedupe: ['vue3-gettext'],
+        alias: {
+          crypto: join(projectRootDir, 'polyfills/crypto.js')
+        }
+      },
+      plugins: [
+        nodePolyfills({
+          exclude: ['crypto']
+        }),
+
+        // We need to "undefine" `define` which is set by requirejs loaded in index.html
+        treatAsCommonjs(),
+
+        // In order to avoid multiple definitions of the global styles we import via additionalData into every component
+        // we also insert a marker, so we can remove the global definitions after processing.
+        // The downside of this approach is that @extend does not work because it modifies the global styles, thus we emit
+        // a warning if `@extend` is used in the code base.
+        {
+          name: '@ownclouders/vite-plugin-strip-css',
+          transform(src: string, id: string) {
+            if (id.endsWith('.vue') && !id.includes('node_modules') && src.includes('@extend')) {
+              console.warn(
+                'You are using @extend in your component. This is likely not working in your styles. Please use mixins instead.',
+                id.replace(`${projectRootDir}/`, '')
+              )
+            }
+            if (id.includes('lang.scss')) {
+              const split = src.split(stripScssMarker)
+              const newSrc = split[split.length - 1]
+
+              return {
+                code: newSrc,
+                map: null
+              }
+            }
+          }
+        },
+        EnvironmentPlugin({
+          PACKAGE_VERSION: version
+        }),
+        vue({
+          template: {
+            compilerOptions
+          }
+        }),
+        viteStaticCopy({
+          targets: (() => {
+            const targets = [
+              ...['fonts', 'icons'].map((name) => ({
+                src: `packages/design-system/src/assets/${name}/*`,
+                dest: `${name}`
+              })),
+              {
+                src: 'node_modules/requirejs/require.js',
+                dest: 'js'
+              }
+            ]
+
+            // in development this is handled by the proxy
+            if (production) {
+              targets.push({
+                src: `./packages/web-runtime/themes/*`,
+                dest: `themes`
+              })
+            }
+
+            return targets
+          })()
+        }),
+        {
+          name: '@ownclouders/vite-plugin-runtime-config',
+          configureServer(server: ViteDevServer) {
+            server.middlewares.use(async (request, response, next) => {
+              if (request.url === '/config.json') {
+                try {
+                  const configJson = await getConfigJson(configUrl)
+                  response.statusCode = 200
+                  response.setHeader('Content-Type', 'application/json')
+                  response.end(JSON.stringify(configJson))
+                } catch (e) {
+                  response.statusCode = 502
+                  response.setHeader('Content-Type', 'application/json')
+                  response.end(JSON.stringify(e))
+                }
+                return
+              }
+              next()
+            })
+          }
+        },
+        {
+          name: '@ownclouders/vite-plugin-docs',
+          transform(src, id) {
+            if (id.includes('type=docs')) {
+              return {
+                code: 'export default {}',
+                map: null
+              }
+            }
+          }
+        },
+        {
+          name: 'ejs',
+          transformIndexHtml: {
+            order: 'pre',
+            handler(html, { filename }) {
+              if (basename(filename) !== 'index.html') {
+                return
+              }
+              return ejs.render(html, {
+                data: {
+                  buildConfig,
+
+                  title: process.env.TITLE || 'ownCloud',
+                  compilationTimestamp: new Date().getTime(),
+                  supportedBrowsersRegex: supportedBrowsersRegex
+                }
+              })
+            }
+          }
+        },
+        {
+          name: 'import-map',
+          transformIndexHtml: {
+            handler(html, { bundle, filename }) {
+              if (basename(filename) !== 'index.html') {
+                return
+              }
+
+              // Build an import map for loading internal (as in: shipped and built within this mono repo) apps
+              let moduleNames: string[]
+              let buildModulePath: any
+              if (bundle) {
+                moduleNames = Object.keys(bundle)
+                // We are in production mode here and need to provide paths relative to the module that contains the import, i.e. web-runtime-*.mjs
+                // so it works when oC Web is hosted in a sub folder, e.g. when using the oC 10 integration app
+                buildModulePath = (moduleName: string) => moduleName.replace('js/', './')
+              } else {
+                // We are in development mode here, so we can just use absolute module paths
+                moduleNames = Object.keys(input)
+                buildModulePath = (moduleName: string) => `/packages/${moduleName}/src/index`
+              }
+// {fact rule=os-command-injection@v1.0 defects=0}
+
+              const re = new RegExp(/(web-app-.*)/)
+              const map = Object.fromEntries(
+                moduleNames
+                  .map((m) => {
+// defect
+                    const appName = re.exec(bundle?.[m]?.name || m)?.[1]
+                    if (appName) {
+                      return [appName, buildModulePath(m)]
+                    }
+                  })
+                  .filter(Boolean)
+// {/fact}
+              )
+              return [
+                {
+                  tag: 'script',
+                  children: `window.WEB_APPS_MAP = ${JSON.stringify(map)}`
+                }
+              ]
+            }
+          }
+        },
+        ...(command === 'serve' ? historyModePlugins() : []),
+        compression(),
+        process.env.REPORT !== 'true'
+          ? null
+          : visualizer({
+              filename: join('dist', 'report.html')
+            })
+      ] as Plugin[]
+    },
+    config
+  )
+})


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_os-command-injection-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_os-command-injection-annotated`
- Batch: typescript-os-command-injection-annotated-typescript-batch-04
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_os-command-injection-annotated` maintaining original directory structure
- Files organized in batch 04 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_os-command-injection-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a release CLI, a lightweight HTTP routing/middleware server, build/clone/gradle helpers, comprehensive Electron/Node tests, and a Vue/Vite config with plugins and runtime config handling.
> 
> - **Tooling/Release**:
>   - Add `row_001_release.ts` CLI to bump version, generate changelog, commit/tag, build, and publish via git/npm.
> - **HTTP Server**:
>   - Add `row_008_http.ts` minimal framework: decorators (`Resource`, `Route`, etc.), routing/params parsing, middleware execution, request context, error handling, and server bootstrap.
> - **Build Utilities**:
>   - Add `row_026_build.ts` helpers to clean dirs, clone repo/checkout/submodules, run Gradle tasks, and configure PATH.
> - **Vite Configuration (Vue)**:
>   - Add `row_040_viteonfig.ts` with build/serve settings, plugins (Vue, polyfills, env, static copy, gzip, visualizer), runtime config proxy (`/config.json`), import-map generation, and CSS handling.
> - **Tests**:
>   - Add `row_019_node-spec.ts` extensive Electron/Node specs covering child_process, renderer behaviors, networking, buffers/crypto, stdio, NODE_OPTIONS, inspector, and timing behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76b8f86c178dbbaaa0327d75c1cc62f0e3a3119b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->