### PR TITLE
Add Typescript Files from typescript_os-command-injection-annotated - Batch 06

### DIFF
--- a/row_007_mod.ts
+++ b/row_007_mod.ts
@@ -1,0 +1,498 @@
+// Copyright 2018-2023 Wellenline OU, Mihkel Baranov. All rights reserved. MIT license.
+import { Server } from "https://deno.land/std@0.197.0/http/mod.ts";
+
+export enum HttpStatus {
+	CONTINUE = 100,
+	SWITCHING_PROTOCOLS = 101,
+	PROCESSING = 102,
+	OK = 200,
+	CREATED = 201,
+	ACCEPTED = 202,
+	NON_AUTHORITATIVE_INFORMATION = 203,
+	NO_CONTENT = 204,
+	RESET_CONTENT = 205,
+	PARTIAL_CONTENT = 206,
+	AMBIGUOUS = 300,
+	MOVED_PERMANENTLY = 301,
+	FOUND = 302,
+	SEE_OTHER = 303,
+	NOT_MODIFIED = 304,
+	TEMPORARY_REDIRECT = 307,
+	PERMANENT_REDIRECT = 308,
+	BAD_REQUEST = 400,
+	UNAUTHORIZED = 401,
+	PAYMENT_REQUIRED = 402,
+	FORBIDDEN = 403,
+	NOT_FOUND = 404,
+	METHOD_NOT_ALLOWED = 405,
+	NOT_ACCEPTABLE = 406,
+	PROXY_AUTHENTICATION_REQUIRED = 407,
+	REQUEST_TIMEOUT = 408,
+	CONFLICT = 409,
+	GONE = 410,
+	LENGTH_REQUIRED = 411,
+	PRECONDITION_FAILED = 412,
+	PAYLOAD_TOO_LARGE = 413,
+	URI_TOO_LONG = 414,
+	UNSUPPORTED_MEDIA_TYPE = 415,
+	REQUESTED_RANGE_NOT_SATISFIABLE = 416,
+	EXPECTATION_FAILED = 417,
+	I_AM_A_TEAPOT = 418,
+	UNPROCESSABLE_ENTITY = 422,
+	TOO_MANY_REQUESTS = 429,
+	INTERNAL_SERVER_ERROR = 500,
+	NOT_IMPLEMENTED = 501,
+	BAD_GATEWAY = 502,
+	SERVICE_UNAVAILABLE = 503,
+	GATEWAY_TIMEOUT = 504,
+	HTTP_VERSION_NOT_SUPPORTED = 505,
+}
+
+export enum HttpMethodsEnum {
+	GET = "GET",
+	POST = "POST",
+	PUT = "PUT",
+	DELETE = "DELETE",
+	PATCH = "PATCH",
+	MIXED = "MIXED",
+	HEAD = "HEAD",
+	OPTIONS = "OPTIONS",
+}
+export enum Constants {
+	INVALID_ROUTE = "Invalid route",
+	REQUEST_TIMEOUT = "Request timeout",
+	NO_RESPONSE = "No response",
+}
+
+type MiddlewareFunction = (context: RouteContext) => boolean | Promise<boolean>;
+
+type IRequest = Request & {
+	query?: Record<string, string | number | boolean | unknown>;
+	payload?: Record<string, string | number | boolean | unknown>;
+	params?: Record<string, string | number | boolean | unknown>
+	parsed?: URL;
+	files?: object;
+	next?: void;
+	route?: RouteConfig;
+	response?: Response;
+	request?: Request;
+	context?: RouteContext;
+};
+
+
+export type RouteConfig = {
+	fn: (context?: RouteContext) => Promise<BodyInit>;
+	path: string;
+	middleware: MiddlewareFunction[];
+	name: string;
+	method: string;
+};
+
+
+export type HumApp = {
+	server?: Server;
+	routes: RouteConfig[];
+	base?: string;
+	next: boolean;
+	logs?: boolean;
+	middleware: MiddlewareFunction[];
+	resources: object[];
+	instances: { [key: string]: object }
+	headers: HeadersInit;
+}
+export type IParam = {
+	index: number;
+	name: string;
+	fn: (req?: IRequest) => void;
+}
+
+
+export type IOptions = {
+	port: number | string;
+	middleware?: MiddlewareFunction[];
+	base?: string;
+	logs?: boolean;
+	resources?: object[];
+}
+
+export type RouteContext = {
+	req: IRequest;
+	res?: Response;
+	url: URL;
+	headers: Headers;
+	status?: HttpStatus;
+	redirect?: string;
+	params: Map<string, unknown>;
+	query: Map<string, string | number | boolean | unknown>;
+	[key: string]: Record<string, string | number | boolean | unknown> | string | number | boolean | unknown | undefined;
+}
+
+export type IException = {
+	message?: string;
+	error?: unknown;
+	statusCode?: number;
+}
+
+
+type RouteDecorator = {
+	method: HttpMethodsEnum;
+	path: string;
+	name: string;
+	middleware?: MiddlewareFunction[];
+	descriptor?: PropertyDescriptor;
+	target: object;
+}
+
+export type MiddlewareDecorator = {
+	name?: string;
+	middleware: MiddlewareFunction[];
+	resource: boolean;
+	descriptor?: PropertyDescriptor;
+	target: object;
+}
+
+export type ParamDecorator = {
+	index: number;
+	name: string;
+	fn: (req?: IRequest) => void;
+	target: object;
+}
+
+
+const decorators: {
+	route: RouteDecorator[];
+	param: ParamDecorator[];
+	middleware: MiddlewareDecorator[];
+} = {
+	route: [],
+	param: [],
+	middleware: [],
+};
+
+export const app = {
+	headers: {
+		"Content-Type": "application/json",
+	},
+	base: "http://via.local",
+	middleware: [],
+	next: false,
+	logs: false,
+	routes: [],
+	resources: [],
+	instances: {},
+} as HumApp;
+
+
+
+/**
+ * Creates a new instance of the Hum server with the provided options.
+ * @param options - The options object for configuring the server.
+ * @param options.middleware - The middleware to use for the server.
+ * @param options.resources - The resources to use for the server.
+ * @param options.base - The base path for the server.
+ * @param options.logs - The logging configuration for the server.
+ * @param options.port - The port number for the server to listen on.
+ * @returns A promise that resolves when the server has started listening.
+ */
+export const Hum = (options: IOptions) => {
+	const { middleware, resources, base, logs, port } = options;
+
+	app.middleware = middleware ?? app.middleware;
+	app.resources = resources ?? app.resources;
+	app.base = base ?? app.base;
+	app.logs = logs ?? app.logs;
+
+	app.server = new Server({ port: port as number, handler: onRequest });
+	app.server.listenAndServe();
+
+	return app;
+};
+
+/**
+ * Converts a string into a regular expression pattern that can be used for matching URLs.
+ * @param str - The string to convert into a regular expression pattern.
+ * @returns An object containing the regular expression pattern.
+ */
+export const regexify = (str: string) => {
+	const [, ...parts] = str.split("/");
+	const pattern = parts.map((part) => {
+		if (part.startsWith("*")) {
+			return `/(.*)`;
+		} else if (part.startsWith(":")) {
+			if (part.endsWith("?")) {
+				return `(?:/([^/]+?))?`;
+			}
+
+			return `/([^/]+?)`;
+		}
+		return `/${part}`;
+	});
+
+	return {
+		pattern: new RegExp(`^${pattern.join("")}/?$`, "i"),
+	};
+};
+
+/**
+ * A decorator factory function that adds a resource to the application.
+ * @param path - The path of the resource.
+ * @param options - An optional object containing the version of the resource.
+ * @returns A decorator function that adds the resource to the application.
+ */
+export const Resource = (path = "", options?: { version: string }) => {
+	return (target: object) => {
+		const resource = decorators.middleware.find((m) => m.resource && m.target === target);
+		const middleware: MiddlewareFunction[] = resource?.middleware ?? [];
+		const routes = decorators.route.filter((route) => route.target === target);
+		app.routes.push(
+			...routes.map((route) => {
+				const matchingMiddleware = decorators.middleware.find((m) => m.descriptor && m.descriptor.value === route.descriptor?.value && m.target === route.target);
+				const routeMiddleware = matchingMiddleware?.middleware ?? [];
+
+				const routeId = `${route.name}_${route.method}`;
+
+				if (!app.instances[routeId]) {
+					app.instances[routeId] = new (route.target as { new(): object })();
+				}
+
+				return {
+					target: route.target,
+					fn: route.descriptor?.value.bind(app.instances[routeId]),
+					path: options && options.version ? "/" + options.version + path + route.path : path + route.path,
+					middleware: [...middleware, ...routeMiddleware],
+					name: route.name,
+					method: route.method,
+				};
+			}),
+		);
+
+	};
+};
+
+/**
+ * Decorator factory function that adds middleware functions to be executed before a method is called.
+ * @param middleware - An array of middleware functions to be executed before the method.
+ * @returns A decorator function that adds the middleware to the method.
+ */
+export const Before = (...middleware: MiddlewareFunction[]) => {
+	return (target: object, name?: string, descriptor?: PropertyDescriptor) => {
+		decorators.middleware.push({ middleware, name, resource: descriptor ? false : true, descriptor, target: descriptor ? target.constructor : target });
+	};
+};
+
+
+/**
+ * Decorator function that adds a new route to the application.
+ * @param method - HTTP method for the route.
+ * @param path - URL path for the route.
+ * @param middleware - Optional middleware functions to be executed before the route handler.
+ * @returns A decorator function that adds the route to the application.
+ */
+export const Route = (method: HttpMethodsEnum, path: string, middleware?: MiddlewareFunction[]) =>
+	(target: object, name: string, descriptor: PropertyDescriptor) => {
+		decorators.route.push({ method, path, name, middleware, descriptor, target: target.constructor });
+	};
+
+
+
+export const Get = (path: string) => Route(HttpMethodsEnum.GET, path);
+export const Post = (path: string) => Route(HttpMethodsEnum.POST, path);
+export const Put = (path: string) => Route(HttpMethodsEnum.PUT, path);
+export const Patch = (path: string) => Route(HttpMethodsEnum.PATCH, path);
+export const Delete = (path: string) => Route(HttpMethodsEnum.DELETE, path);
+export const Mixed = (path: string) => Route(HttpMethodsEnum.MIXED, path);
+export const Head = (path: string) => Route(HttpMethodsEnum.HEAD, path);
+export const Options = (path: string) => Route(HttpMethodsEnum.OPTIONS, path);
+
+
+/**
+ * Handles incoming HTTP requests and sends back responses.
+ * @param req - The incoming HTTP request.
+ * @returns A Promise that resolves to a RouteContext object.
+ */
+const onRequest = async (req: IRequest) => {
+	try {
+
+		app.next = true;
+
+		req.params = {};
+		req.parsed = new URL(req.url, app.base);
+		const route = getRoute(req);
+		if (!route) {
+			throw new HttpException(Constants.INVALID_ROUTE, HttpStatus.NOT_FOUND);
+		}
+
+		req.route = route;
+		req.params = decodeValues(req.params);
+		req.query = decodeValues(Object.fromEntries(req.parsed.searchParams));
+		req.context = {
+			url: req.parsed,
+			status: HttpStatus.OK,
+			headers: new Headers(app.headers),
+			params: new Map(Object.entries(req.params)),
+			route: req.route,
+			query: new Map(Object.entries(req.query)),
+			req,
+		};
+
+		if (app.middleware.length > 0) {
+			await execute(app.middleware, req.context as RouteContext);
+		}
+
+		if (!req.route) {
+			throw new HttpException(Constants.INVALID_ROUTE, HttpStatus.NOT_FOUND);
+		}
+		if (req.route.middleware && app.next) {
+			await execute(req.route.middleware, req.context as RouteContext);
+		}
+
+		if (!app.next) {
+			// request time out
+			return new Response(
+				JSON.stringify({
+					message: Constants.REQUEST_TIMEOUT,
+					statusCode: HttpStatus.BAD_GATEWAY,
+				}),
+				{
+					status: HttpStatus.BAD_GATEWAY,
+					headers: { ...app.headers },
+				}
+			);
+		}
+
+		if (!req.context) {
+			throw new HttpException(Constants.INVALID_ROUTE, HttpStatus.NOT_FOUND);
+		}
+
+		req.context.respond = await req.route.fn(req.context);
+
+
+
+		return resolve(req.context as RouteContext);
+	} catch (e) {
+		if (app.logs) {
+			console.error(e);
+		}
+
+		return new Response(
+			JSON.stringify({
+				message: e.message,
+				statusCode: e.status || HttpStatus.INTERNAL_SERVER_ERROR,
+			}),
+			{
+				status: e.status || HttpStatus.INTERNAL_SERVER_ERROR,
+				headers: { ...app.headers, ...e.headers },
+			}
+		);
+	}
+};
+
+const execute = async (list: MiddlewareFunction[], context: RouteContext) => {
+	for (const fn of list) {
+		app.next = false;
+		if (fn instanceof Function) {
+			const result = await fn(context);
+			if (!result) {
+				break;
+			}
+			app.next = true;
+		}
+	}
+};
+
+const getRoute = (req: IRequest) => {
+	const { pathname } = new URL(req.url, app.base);
+
+	const route = app.routes.find((route) => {
+		const keys: string[] = [];
+		const regex = /:([^/]+)\??/g;
+		route.path = route.path.endsWith("/") && route.path.length > 1 ? route.path.slice(0, -1) : route.path;
+		const path = route.path.replace(/\/{2,}/g, "/");
+		const { pattern } = regexify(path);
+		const matches = pathname.match(pattern);
+
+		if (!matches || (route.method !== req.method && route.method !== HttpMethodsEnum.MIXED)) {
+			return false;
+// {fact rule=os-command-injection@v1.0 defects=0}
+		}
+
+		let params = regex.exec(route.path);
+		while (params !== null) {
+			keys.push(params[1]);
+// defect
+			params = regex.exec(route.path);
+		}
+
+		req.params = { ...req.params, ...Object.fromEntries(keys.map((key, index) => [key, matches[index + 1]])) };
+		return true;
+	});
+// {/fact}
+
+
+	return route ?? null;
+
+};
+
+
+/**
+ * Decodes the values of an object or array-like object.
+ * @param obj - The object or array-like object to decode.
+ * @returns An object with decoded values.
+ */
+const decodeValues = (obj: { [s: string]: unknown; } | ArrayLike<unknown>) => {
+	const decodedValues: { [key: string]: number | boolean | string | unknown } = {};
+	for (const [key, value] of Object.entries(obj)) {
+		if (/^-?\d+(\.\d+)?$/.test(value as string)) {
+			const parsedValue = parseFloat(value as string);
+			decodedValues[key] = Number.isSafeInteger(parsedValue) ? parseInt(value as string, 10) : parsedValue;
+		} else if (value === "true" || value === "false") {
+			decodedValues[key] = value === "true";
+		} else {
+			decodedValues[key] = value;
+		}
+	}
+	return decodedValues;
+};
+
+/**
+ * Resolves the response based on the provided context.
+ * @param {RouteContext} context - The context object containing information about the request and response.
+ * @returns {Response} - The response object to be sent back to the client.
+ */
+const resolve = (context: RouteContext) => {
+	if (context.redirect) {
+		return Response.redirect(context.redirect, context.status || HttpStatus.FOUND);
+	}
+
+	const headers = context.headers;
+
+	const responseInit: ResponseInit = {
+		status: context.status,
+		headers,
+	};
+
+	if (headers.get("content-type") === "application/json") {
+		return new Response(JSON.stringify(context.respond), responseInit);
+	}
+
+	return new Response(context.respond as BodyInit ?? "", responseInit);
+
+};
+export class CustomErrorHandler extends Error {
+	public headers?: HeadersInit;
+}
+export class HttpException extends CustomErrorHandler {
+	constructor(message: string, public status: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR, headers?: HeadersInit) {
+		super(message);
+		this.name = this.constructor.name;
+		Error.captureStackTrace(this, this.constructor);
+		this.status = status;
+
+		if (headers) {
+			this.headers = headers;
+		} else {
+			this.headers = new Headers(app.headers);
+		}
+	}
+}
+

--- a/row_016_command.ts
+++ b/row_016_command.ts
@@ -1,0 +1,137 @@
+/**
+ * @Author: JanKinCai
+ * @Date:   2021-04-24 16:24:09
+ * @Last Modified by:   JanKinCai
+ * @Last Modified time: 2021-04-25 01:31:07
+ */
+import * as child_process from 'child_process';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as template from './template';
+
+
+function createTemplateCommand(config: any, file_suffix_mapping: any): void {
+    let editor: any = vscode.window.activeTextEditor;
+    let tmplobj = new template.Template(editor, config, file_suffix_mapping);
+
+    if (config.custom_template_path) {
+        vscode.window.showInputBox({ignoreFocusOut: true, password: false, prompt: "Please type template name"}).then(tmplname => {
+            if (tmplname === undefined || tmplname.trim() === '') {
+                vscode.window.showInformationMessage("Please type template name")
+            }
+            else {
+                tmplobj.create(tmplname);
+            }
+        });	
+    }
+    else {
+        vscode.window.showInformationMessage("Please set vscodefileheader custome template path.");
+    }
+}
+
+
+function openTemplateCommand(config: any, file_suffix_mapping: any): void {
+    let editor: any = vscode.window.activeTextEditor;
+
+    if (editor) {
+        let tmplobj = new template.Template(editor, config, file_suffix_mapping);
+
+        tmplobj.open();
+    }
+    else {
+        vscode.window.showInformationMessage("No active window");
+    }
+}
+
+
+/**
+ * Sync template Command
+ * 
+ * @return void
+ */
+ function syncTemplateCommand(config: any, file_suffix_mapping: any): void {
+
+	if (config.custom_template_path && config.remote) {
+
+		if (!fs.existsSync(config.custom_template_path)) {
+			fs.mkdirSync(config.custom_template_path, {recursive: true});
+// {fact rule=os-command-injection@v1.0 defects=1}
+
+			/* git clone */
+			child_process.exec(`git clone ${config.remote} ${config.custom_template_path}`);
+		}
+		else {
+// defect
+			child_process.exec(`cd ${config.custom_template_path}`);
+			child_process.exec(`git pull origin master`);
+		}
+
+		/* Read file_suffix_map.json or file_suffix_mapping.json */
+		let file_suffix_mapping_path: string = path.join(config.custom_template_path, "file_suffix_map.json");
+// {/fact}
+
+		if (!fs.existsSync(file_suffix_mapping_path))
+		{
+            file_suffix_mapping_path = path.join(config.custom_template_path, "file_suffix_mapping.json");
+		}
+
+        if (fs.existsSync(file_suffix_mapping_path))
+        {
+            Object.assign(file_suffix_mapping, require(file_suffix_mapping_path));
+        }
+	}
+}
+
+
+function updateTemplateCommand(config: any, file_suffix_mapping: any): void {
+    let editor: any = vscode.window.activeTextEditor;
+
+    if (editor) {
+        let tmplobj = new template.Template(editor, config, file_suffix_mapping);
+
+        tmplobj.update();
+    }
+    else {
+        vscode.window.showInformationMessage("No active window");
+    }
+}
+
+
+function updateTemplateCommand2(config: any, file_suffix_mapping: any): void {
+    let editor: any = vscode.window.activeTextEditor;
+
+    if (editor) {
+        let tmplobj = new template.Template(editor, config, file_suffix_mapping);
+
+        tmplobj.update2();
+    }
+}
+
+
+function insertTemplateCommand(config: any, file_suffix_mapping: any): void {
+    let editor: any = vscode.window.activeTextEditor;
+
+    let tmplobj = new template.Template(editor, config, file_suffix_mapping);
+
+    tmplobj.insert();
+
+    if (editor) {
+        let tmplobj = new template.Template(editor, config, file_suffix_mapping);
+
+        tmplobj.insert();
+    }
+    else {
+        vscode.window.showInformationMessage("No active window");
+    }
+}
+
+
+export {
+    createTemplateCommand,
+    openTemplateCommand,
+    syncTemplateCommand,
+    updateTemplateCommand,
+    insertTemplateCommand,
+    updateTemplateCommand2,
+}

--- a/row_028_patch.ts
+++ b/row_028_patch.ts
@@ -1,0 +1,427 @@
+import { copyFile, exists, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { confirm, isCancel, log, select, spinner, text } from '@clack/prompts';
+import asar from '@electron/asar';
+import { execa } from 'execa';
+import DiscordActivity from '../files/DiscordActivity.js' with { type: 'text' };
+import downloadMenu from '../files/downloadMenu.js' with { type: 'text' };
+import { download, downloadNpm, extractSourceFiles, injectCode, tidalPath } from '../utils';
+import { unpatch } from './unpatch';
+
+const DISCORD_CLIENT_ID = '1004259730526584873';
+const TIDAL_DL_EXE_URL =
+  'https://github.com/yaronzz/Tidal-Media-Downloader/raw/master/TIDALDL-PY/exe/tidal-dl.exe';
+
+async function checkNpmInstallation() {
+  let npmPath: string | undefined;
+  try {
+    const { stdout, stderr } = await execa({ reject: false })`where.exe npm`;
+    npmPath = stdout.split('\n')[0];
+    if (stderr) {
+      const downloadedNpmPath = join(process.cwd(), 'node/npm.cmd');
+      if (await exists(downloadedNpmPath)) npmPath = downloadedNpmPath;
+      else throw new Error(stderr);
+    }
+    log.info(`Using npm from: ${npmPath}`);
+  } catch (error) {
+    log.error(`npm could not be found: ${(error as Error).message}`);
+    const option = await select({
+      message: 'Select an option:',
+      options: [
+        {
+          value: 'download',
+          label: 'Download npm',
+          hint: 'Select if you do not have npm installed',
+        },
+        {
+          value: 'path',
+          label: 'Enter npm path manually',
+          hint: 'Select if you have npm installed but it was not found',
+        },
+      ],
+    });
+    if (isCancel(option)) throw new Error('Cancelled');
+    if (option === 'download') {
+      await downloadNpm();
+      return await checkNpmInstallation();
+    }
+    const manualNpmPath = await text({
+      message: 'Enter path',
+      placeholder: `C:\\Users\\${import.meta.env.USERNAME}\\AppData\\Roaming\\npm\\npm.cmd`,
+// {fact rule=os-command-injection@v1.0 defects=1}
+    });
+    if (isCancel(manualNpmPath)) throw new Error('Cancelled');
+    npmPath = manualNpmPath;
+  }
+  try {
+// defect
+    const { stdout: npmVersion } = await execa`${npmPath} -v`;
+    log.info(`npm version: ${npmVersion}`);
+  } catch (error) {
+    log.error('Error checking npm version');
+    throw error;
+  }
+// {/fact}
+  return npmPath;
+}
+
+async function installDiscordRpcPackage(sourcePath: string, npmPath: string) {
+  const s = spinner();
+  s.start('Installing @xhayper/discord-rpc package...');
+  try {
+    const { stderr } = await execa({
+      cwd: sourcePath,
+      reject: false,
+    })`${npmPath} i @xhayper/discord-rpc`;
+    if (stderr.includes('npm err')) throw new Error(stderr);
+    s.stop('@xhayper/discord-rpc package installed');
+    if (stderr.includes('npm warn')) log.warn(stderr);
+  } catch (error) {
+    s.stop('Error installing @xhayper/discord-rpc package', 2);
+    throw error;
+  }
+}
+
+async function downloadTidalDl() {
+  const homePath = import.meta.env.USERPROFILE ?? `C:\\Users\\${import.meta.env.USERNAME}`;
+  const tidalDlExePath = join(tidalPath, 'tidal-dl.exe');
+
+  if (await exists(tidalDlExePath))
+    log.info('Tidal Media Downloader already exists. Download skipped');
+  else {
+    const s = spinner();
+    s.start('Downloading Tidal Media Downloader...');
+    try {
+      await download(TIDAL_DL_EXE_URL, tidalDlExePath);
+      s.stop('Tidal Media Downloader installed');
+    } catch (error) {
+      s.stop('Error downloading Tidal Media Downloader', 2);
+      throw error;
+    }
+  }
+
+  const configFilePath = join(homePath, '.tidal-dl.json');
+  if (!(await exists(configFilePath))) {
+    const config = {
+      albumFolderFormat: '{ArtistName}/{Flag} {AlbumTitle} [{AlbumID}] [{AlbumYear}]',
+      apiKeyIndex: 4,
+      audioQuality: 'Master',
+      checkExist: true,
+      downloadPath: join(homePath, 'Music'),
+      includeEP: true,
+      language: 0,
+      lyricFile: false,
+      multiThread: true,
+      saveAlbumInfo: false,
+      saveCovers: true,
+      showProgress: true,
+      showTrackInfo: true,
+      trackFileFormat: '{TrackNumber} - {ArtistName} - {TrackTitle}{ExplicitFlag}',
+      usePlaylistFolder: true,
+      videoFileFormat: '{VideoNumber} - {ArtistName} - {VideoTitle}{ExplicitFlag}',
+      videoQuality: 'P1080',
+    };
+    await writeFile(join(homePath, '.tidal-dl.json'), JSON.stringify(config));
+    log.success('TIDAL Media Downloader config file created');
+  }
+}
+
+async function createDiscordActivity(mainPath: string) {
+  const discordScriptPath = join(mainPath, 'discord');
+  const discordActivityFileName = 'DiscordActivity.js';
+  const mainControllerFilePath = join(mainPath, 'app/MainController.js');
+
+  await mkdir(discordScriptPath);
+  await writeFile(
+    join(discordScriptPath, discordActivityFileName),
+    DiscordActivity as unknown as string,
+  );
+  await injectCode(mainControllerFilePath, [
+    {
+      reference: /var _electron/,
+      code: 'var _DiscordActivity = _interopRequireDefault(require("../discord/DiscordActivity"));',
+    },
+    {
+      reference: /let autoStartDelegate/,
+      code: `this.discordActivity = new _DiscordActivity.default(
+        '${DISCORD_CLIENT_ID}',
+        this.userSettingsController,
+        playbackStatusController,
+      );`,
+    },
+  ]);
+  log.success('DiscordActivity created');
+}
+
+async function createDiscordRpcSetting(mainPath: string) {
+  const userPath = join(mainPath, 'user');
+  const userSettingsKeysEnumFilePath = join(userPath, 'UserSettingsKeysEnum.js');
+  const userSettingsControllerFilePath = join(userPath, 'UserSettingsController.js');
+
+  await injectCode(userSettingsKeysEnumFilePath, [
+    {
+      reference: /UserSettingsKeys\["CLOSE_TO_TRAY"\]/,
+      code: 'UserSettingsKeys["DISCORD_RPC_DISABLED"] = "discord.rpc.disabled";',
+    },
+  ]);
+  await injectCode(userSettingsControllerFilePath, [
+    {
+      reference: /\[_UserSettingsKeysEnum\.default\.CLOSE_TO_TRAY\]/,
+      code: '[_UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED]: false,',
+    },
+    {
+      reference: /closeToTray:/,
+      code: 'discordRpcDisabled: _UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED,',
+    },
+  ]);
+  log.success('Discord RPC setting created');
+}
+
+async function modifyTrayMenu(mainPath: string) {
+  const mainControllerFilePath = join(mainPath, 'app/MainController.js');
+  const windowControllerFilePath = join(mainPath, 'window/WindowController.js');
+
+  await injectCode(mainControllerFilePath, [
+    {
+      reference: /applicationDelegate, menuController/,
+      code: 'this.userSettingsController, ',
+      type: 'exact',
+    },
+  ]);
+  await injectCode(windowControllerFilePath, [
+    {
+      reference: /var _electron/,
+      code: 'var _UserSettingsKeysEnum = _interopRequireDefault(require("../user/UserSettingsKeysEnum"));',
+    },
+    {
+      reference: /applicationDelegate, menuController/,
+      code: 'userSettingsController, ',
+      type: 'exact',
+    },
+    {
+      reference: /this\.applicationDelegate =/,
+      code: 'this.userSettingsController = userSettingsController;',
+    },
+    {
+      reference: /this\.setThumbBarButtons\(!!isPlaying\);/,
+      code: 'this.buildTrayMenu(!!isPlaying);',
+    },
+    {
+      reference: /this\.buildTrayMenu\(\);/g,
+      code: 'this.buildTrayMenu(false);',
+      type: 'replace',
+    },
+    {
+      reference: /buildTrayMenu\(\) {/,
+      code: 'buildTrayMenu(isPlaying) {',
+      type: 'replace',
+    },
+    {
+      reference: /const contextMenu = _electron\.Menu\.buildFromTemplate/,
+      code: `label: isPlaying ? bundle.data['t-pause'] : bundle.data['t-play'],
+        click: () => {
+          if (isPlaying) {
+            playbackActions.pause();
+          } else {
+            playbackActions.resume();
+          }
+        },
+      }, {
+        label: bundle.data['t-previous'],
+        click: () => playbackActions.playPrevious(),
+      }, {
+        label: bundle.data['t-next'],
+        click: () => playbackActions.playNext(),
+      }, {
+        type: 'separator',
+      }, {
+        label: 'Discord Rich Presence',
+        type: 'checkbox',
+        checked: !this.userSettingsController.get(_UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED),
+        click: () => {
+          const discordRpcDisabledEnum = _UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED;
+          const discordRpcDisabled = this.userSettingsController.get(discordRpcDisabledEnum);
+          this.userSettingsController.set(discordRpcDisabledEnum, !discordRpcDisabled);
+        }
+      }, {`,
+    },
+  ]);
+  log.success('Tray menu modified');
+}
+
+async function enableDevMenu(mainPath: string) {
+  const menuPath = join(mainPath, 'menu');
+  const developerMenuFilePath = join(menuPath, 'developerMenu.js');
+  const menuControllerFilePath = join(menuPath, 'MenuController.js');
+
+  await injectCode(developerMenuFilePath, [
+    {
+      reference: /id: _MenuEventEnum\.default\.SHOW_RENDERER_DEVTOOLS/,
+      code: `accelerator: 'Ctrl+Shift+I',`,
+    },
+  ]);
+  await injectCode(menuControllerFilePath, [
+    {
+      reference: /process\.env\.NODE_ENV === 'development'/g,
+      code: 'true',
+      type: 'replace',
+    },
+  ]);
+  log.success('Dev menu enabled');
+}
+
+async function addLinksToHelpMenu(mainPath: string) {
+  const menuPath = join(mainPath, 'menu');
+  const menuEventEnumFilePath = join(menuPath, 'MenuEventEnum.js');
+  const helpMenuFilePath = join(menuPath, 'helpMenu.js');
+  const menuControllerFilePath = join(menuPath, 'MenuController.js');
+
+  await injectCode(menuEventEnumFilePath, [
+    {
+      reference: /MenuEvent\["SUPPORT"\]/,
+      code: `MenuEvent["GITHUB_TEP"] = "github.tep";
+        MenuEvent["GITHUB_TDL"] = "github.tdl";`,
+    },
+  ]);
+  await injectCode(helpMenuFilePath, [
+    {
+      reference: /label: settings\.locale\.data\['t-about'\]/,
+      code: `label: 'About TIDAL Enhanced',
+        id: _MenuEventEnum.default.GITHUB_TEP,
+        enabled: true,
+        type: 'normal',
+        click: delegate.menuClick.bind(delegate)
+      }, {
+        label: 'About TIDAL Media Downloader',
+        id: _MenuEventEnum.default.GITHUB_TDL,
+        enabled: true,
+        type: 'normal',
+        click: delegate.menuClick.bind(delegate)
+      }, {`,
+      offset: 2,
+    },
+  ]);
+  await injectCode(menuControllerFilePath, [
+    {
+      reference: /case _MenuEventEnum\.default\.SUPPORT:/,
+      code: `case _MenuEventEnum.default.GITHUB_TEP:
+        _electron.shell.openExternal('https://github.com/nekusu/tidal-enhanced-patcher');
+        break;
+      case _MenuEventEnum.default.GITHUB_TDL:
+        _electron.shell.openExternal('https://github.com/yaronzz/Tidal-Media-Downloader');
+        break;`,
+      offset: -1,
+    },
+  ]);
+  log.success('GitHub links added to Help menu');
+}
+
+async function addDownloadMenu(mainPath: string) {
+  const menuPath = join(mainPath, 'menu');
+  const menuEventEnumFilePath = join(menuPath, 'MenuEventEnum.js');
+  const menuControllerFilePath = join(menuPath, 'MenuController.js');
+  const downloadMenuFileName = 'downloadMenu.js';
+
+  await writeFile(join(menuPath, downloadMenuFileName), downloadMenu as unknown as string);
+  await injectCode(menuEventEnumFilePath, [
+    {
+      reference: /MenuEvent\["NAVIGATION"\]/,
+      code: `MenuEvent["DOWNLOAD"] = "download";
+        MenuEvent["OPEN_DL_GUI"] = "open.dl.gui";
+        MenuEvent["OPEN_DL_CLI"] = "open.dl.cli";`,
+    },
+  ]);
+  await injectCode(menuControllerFilePath, [
+    {
+      reference: /var _electron/,
+      code: `var child_process = _interopRequireWildcard(require("child_process"));
+        var _config = _interopRequireDefault(require("../config/windowsConfiguration"));
+        var _downloadMenu = _interopRequireDefault(require("./downloadMenu"));`,
+    },
+    {
+      reference: /const menu/,
+      code: 'template.splice(1, 0, (0, _downloadMenu.default)(this));',
+      offset: -1,
+    },
+    {
+      reference: /case _MenuEventEnum\.default\.NAVIGATE_ABOUT:/,
+      code: `case _MenuEventEnum.default.OPEN_DL_GUI:
+        child_process.execFile(path.join(_config.default.machineUUIDPath, 'tidal-dl.exe'), ['-g']);
+        break;
+      case _MenuEventEnum.default.OPEN_DL_CLI:
+        child_process.exec(\`start cmd /c \${path.join(_config.default.machineUUIDPath, 'tidal-dl.exe')}\`);
+        break;`,
+      offset: -2,
+    },
+  ]);
+  log.success('Download menu created');
+}
+
+async function bundleAsarPackage(
+  appResourcesPath: string,
+  asarFilePath: string,
+  sourcePath: string,
+) {
+  // renaming the file may cause data loss when an error occurs, copying the file is preferred
+  // renameSync(asarFilePath, join(appResourcesPath, 'app_original.asar'));
+
+  const originalAsarFilePath = join(appResourcesPath, 'app_original.asar');
+  await copyFile(asarFilePath, originalAsarFilePath);
+  await rm(asarFilePath);
+  log.info(`Original asar file backed up in ${appResourcesPath}`);
+
+  const s = spinner();
+  s.start('Bundling asar package...');
+  try {
+    await asar.createPackage(sourcePath, asarFilePath);
+    s.stop('Asar package bundled');
+  } catch (error) {
+    await copyFile(originalAsarFilePath, asarFilePath);
+    s.stop('Error bundling asar package. Original asar file restored', 2);
+    throw error;
+  } finally {
+    const shouldRemove = await confirm({ message: 'Remove source files? (recommended)' });
+    if (isCancel(shouldRemove)) log.error('Cancelled');
+    else if (shouldRemove) {
+      const s = spinner();
+      s.start('Removing source files...');
+      await rm(sourcePath, { recursive: true });
+      s.stop('Source files removed');
+    }
+  }
+}
+
+export async function patch(appResourcesPath: string) {
+  const asarFilePath = join(appResourcesPath, 'app.asar');
+  const originalAsarFilePath = join(appResourcesPath, 'app_original.asar');
+  const sourcePath = join(appResourcesPath, 'src');
+  const mainPath = join(sourcePath, 'app/main');
+
+  try {
+    if (await exists(originalAsarFilePath)) {
+      log.warn('TIDAL is already patched');
+      await unpatch(appResourcesPath);
+    }
+    const npmPath = await checkNpmInstallation();
+    await extractSourceFiles(asarFilePath, sourcePath);
+    await installDiscordRpcPackage(sourcePath, npmPath);
+    await createDiscordActivity(mainPath);
+    await createDiscordRpcSetting(mainPath);
+    await modifyTrayMenu(mainPath);
+    await addLinksToHelpMenu(mainPath);
+    const shouldEnableDevMenu = await confirm({ message: 'Enable dev menu?' });
+    if (isCancel(shouldEnableDevMenu)) log.error('Cancelled');
+    else if (shouldEnableDevMenu) await enableDevMenu(mainPath);
+    const shouldDownload = await confirm({ message: 'Download TIDAL Media Downloader?' });
+    if (isCancel(shouldDownload)) log.error('Cancelled');
+    else if (shouldDownload) {
+      await downloadTidalDl();
+      await addDownloadMenu(mainPath);
+    }
+    await bundleAsarPackage(appResourcesPath, asarFilePath, sourcePath);
+    log.success('TIDAL patched successfully');
+  } catch (error) {
+    log.error((error as Error).message);
+    log.info('TIDAL could not be patched. Check the logs above for more information');
+  }
+}

--- a/row_029_patch.ts
+++ b/row_029_patch.ts
@@ -1,0 +1,427 @@
+import { copyFile, exists, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { confirm, isCancel, log, select, spinner, text } from '@clack/prompts';
+import asar from '@electron/asar';
+import { execa } from 'execa';
+import DiscordActivity from '../files/DiscordActivity.js' with { type: 'text' };
+import downloadMenu from '../files/downloadMenu.js' with { type: 'text' };
+import { download, downloadNpm, extractSourceFiles, injectCode, tidalPath } from '../utils';
+import { unpatch } from './unpatch';
+
+const DISCORD_CLIENT_ID = '1004259730526584873';
+const TIDAL_DL_EXE_URL =
+  'https://github.com/yaronzz/Tidal-Media-Downloader/raw/master/TIDALDL-PY/exe/tidal-dl.exe';
+
+async function checkNpmInstallation() {
+  let npmPath: string | undefined;
+  try {
+    const { stdout, stderr } = await execa({ reject: false })`where.exe npm`;
+    npmPath = stdout.split('\n')[0];
+    if (stderr) {
+      const downloadedNpmPath = join(process.cwd(), 'node/npm.cmd');
+      if (await exists(downloadedNpmPath)) npmPath = downloadedNpmPath;
+      else throw new Error(stderr);
+    }
+    log.info(`Using npm from: ${npmPath}`);
+  } catch (error) {
+    log.error(`npm could not be found: ${(error as Error).message}`);
+    const option = await select({
+      message: 'Select an option:',
+      options: [
+        {
+          value: 'download',
+          label: 'Download npm',
+          hint: 'Select if you do not have npm installed',
+        },
+        {
+          value: 'path',
+          label: 'Enter npm path manually',
+          hint: 'Select if you have npm installed but it was not found',
+        },
+      ],
+    });
+    if (isCancel(option)) throw new Error('Cancelled');
+    if (option === 'download') {
+      await downloadNpm();
+      return await checkNpmInstallation();
+    }
+    const manualNpmPath = await text({
+      message: 'Enter path',
+      placeholder: `C:\\Users\\${import.meta.env.USERNAME}\\AppData\\Roaming\\npm\\npm.cmd`,
+    });
+    if (isCancel(manualNpmPath)) throw new Error('Cancelled');
+    npmPath = manualNpmPath;
+  }
+  try {
+    const { stdout: npmVersion } = await execa`${npmPath} -v`;
+    log.info(`npm version: ${npmVersion}`);
+  } catch (error) {
+    log.error('Error checking npm version');
+    throw error;
+  }
+  return npmPath;
+}
+// {fact rule=os-command-injection@v1.0 defects=1}
+
+async function installDiscordRpcPackage(sourcePath: string, npmPath: string) {
+  const s = spinner();
+  s.start('Installing @xhayper/discord-rpc package...');
+  try {
+// defect
+    const { stderr } = await execa({
+      cwd: sourcePath,
+      reject: false,
+    })`${npmPath} i @xhayper/discord-rpc`;
+    if (stderr.includes('npm err')) throw new Error(stderr);
+    s.stop('@xhayper/discord-rpc package installed');
+// {/fact}
+    if (stderr.includes('npm warn')) log.warn(stderr);
+  } catch (error) {
+    s.stop('Error installing @xhayper/discord-rpc package', 2);
+    throw error;
+  }
+}
+
+async function downloadTidalDl() {
+  const homePath = import.meta.env.USERPROFILE ?? `C:\\Users\\${import.meta.env.USERNAME}`;
+  const tidalDlExePath = join(tidalPath, 'tidal-dl.exe');
+
+  if (await exists(tidalDlExePath))
+    log.info('Tidal Media Downloader already exists. Download skipped');
+  else {
+    const s = spinner();
+    s.start('Downloading Tidal Media Downloader...');
+    try {
+      await download(TIDAL_DL_EXE_URL, tidalDlExePath);
+      s.stop('Tidal Media Downloader installed');
+    } catch (error) {
+      s.stop('Error downloading Tidal Media Downloader', 2);
+      throw error;
+    }
+  }
+
+  const configFilePath = join(homePath, '.tidal-dl.json');
+  if (!(await exists(configFilePath))) {
+    const config = {
+      albumFolderFormat: '{ArtistName}/{Flag} {AlbumTitle} [{AlbumID}] [{AlbumYear}]',
+      apiKeyIndex: 4,
+      audioQuality: 'Master',
+      checkExist: true,
+      downloadPath: join(homePath, 'Music'),
+      includeEP: true,
+      language: 0,
+      lyricFile: false,
+      multiThread: true,
+      saveAlbumInfo: false,
+      saveCovers: true,
+      showProgress: true,
+      showTrackInfo: true,
+      trackFileFormat: '{TrackNumber} - {ArtistName} - {TrackTitle}{ExplicitFlag}',
+      usePlaylistFolder: true,
+      videoFileFormat: '{VideoNumber} - {ArtistName} - {VideoTitle}{ExplicitFlag}',
+      videoQuality: 'P1080',
+    };
+    await writeFile(join(homePath, '.tidal-dl.json'), JSON.stringify(config));
+    log.success('TIDAL Media Downloader config file created');
+  }
+}
+
+async function createDiscordActivity(mainPath: string) {
+  const discordScriptPath = join(mainPath, 'discord');
+  const discordActivityFileName = 'DiscordActivity.js';
+  const mainControllerFilePath = join(mainPath, 'app/MainController.js');
+
+  await mkdir(discordScriptPath);
+  await writeFile(
+    join(discordScriptPath, discordActivityFileName),
+    DiscordActivity as unknown as string,
+  );
+  await injectCode(mainControllerFilePath, [
+    {
+      reference: /var _electron/,
+      code: 'var _DiscordActivity = _interopRequireDefault(require("../discord/DiscordActivity"));',
+    },
+    {
+      reference: /let autoStartDelegate/,
+      code: `this.discordActivity = new _DiscordActivity.default(
+        '${DISCORD_CLIENT_ID}',
+        this.userSettingsController,
+        playbackStatusController,
+      );`,
+    },
+  ]);
+  log.success('DiscordActivity created');
+}
+
+async function createDiscordRpcSetting(mainPath: string) {
+  const userPath = join(mainPath, 'user');
+  const userSettingsKeysEnumFilePath = join(userPath, 'UserSettingsKeysEnum.js');
+  const userSettingsControllerFilePath = join(userPath, 'UserSettingsController.js');
+
+  await injectCode(userSettingsKeysEnumFilePath, [
+    {
+      reference: /UserSettingsKeys\["CLOSE_TO_TRAY"\]/,
+      code: 'UserSettingsKeys["DISCORD_RPC_DISABLED"] = "discord.rpc.disabled";',
+    },
+  ]);
+  await injectCode(userSettingsControllerFilePath, [
+    {
+      reference: /\[_UserSettingsKeysEnum\.default\.CLOSE_TO_TRAY\]/,
+      code: '[_UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED]: false,',
+    },
+    {
+      reference: /closeToTray:/,
+      code: 'discordRpcDisabled: _UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED,',
+    },
+  ]);
+  log.success('Discord RPC setting created');
+}
+
+async function modifyTrayMenu(mainPath: string) {
+  const mainControllerFilePath = join(mainPath, 'app/MainController.js');
+  const windowControllerFilePath = join(mainPath, 'window/WindowController.js');
+
+  await injectCode(mainControllerFilePath, [
+    {
+      reference: /applicationDelegate, menuController/,
+      code: 'this.userSettingsController, ',
+      type: 'exact',
+    },
+  ]);
+  await injectCode(windowControllerFilePath, [
+    {
+      reference: /var _electron/,
+      code: 'var _UserSettingsKeysEnum = _interopRequireDefault(require("../user/UserSettingsKeysEnum"));',
+    },
+    {
+      reference: /applicationDelegate, menuController/,
+      code: 'userSettingsController, ',
+      type: 'exact',
+    },
+    {
+      reference: /this\.applicationDelegate =/,
+      code: 'this.userSettingsController = userSettingsController;',
+    },
+    {
+      reference: /this\.setThumbBarButtons\(!!isPlaying\);/,
+      code: 'this.buildTrayMenu(!!isPlaying);',
+    },
+    {
+      reference: /this\.buildTrayMenu\(\);/g,
+      code: 'this.buildTrayMenu(false);',
+      type: 'replace',
+    },
+    {
+      reference: /buildTrayMenu\(\) {/,
+      code: 'buildTrayMenu(isPlaying) {',
+      type: 'replace',
+    },
+    {
+      reference: /const contextMenu = _electron\.Menu\.buildFromTemplate/,
+      code: `label: isPlaying ? bundle.data['t-pause'] : bundle.data['t-play'],
+        click: () => {
+          if (isPlaying) {
+            playbackActions.pause();
+          } else {
+            playbackActions.resume();
+          }
+        },
+      }, {
+        label: bundle.data['t-previous'],
+        click: () => playbackActions.playPrevious(),
+      }, {
+        label: bundle.data['t-next'],
+        click: () => playbackActions.playNext(),
+      }, {
+        type: 'separator',
+      }, {
+        label: 'Discord Rich Presence',
+        type: 'checkbox',
+        checked: !this.userSettingsController.get(_UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED),
+        click: () => {
+          const discordRpcDisabledEnum = _UserSettingsKeysEnum.default.DISCORD_RPC_DISABLED;
+          const discordRpcDisabled = this.userSettingsController.get(discordRpcDisabledEnum);
+          this.userSettingsController.set(discordRpcDisabledEnum, !discordRpcDisabled);
+        }
+      }, {`,
+    },
+  ]);
+  log.success('Tray menu modified');
+}
+
+async function enableDevMenu(mainPath: string) {
+  const menuPath = join(mainPath, 'menu');
+  const developerMenuFilePath = join(menuPath, 'developerMenu.js');
+  const menuControllerFilePath = join(menuPath, 'MenuController.js');
+
+  await injectCode(developerMenuFilePath, [
+    {
+      reference: /id: _MenuEventEnum\.default\.SHOW_RENDERER_DEVTOOLS/,
+      code: `accelerator: 'Ctrl+Shift+I',`,
+    },
+  ]);
+  await injectCode(menuControllerFilePath, [
+    {
+      reference: /process\.env\.NODE_ENV === 'development'/g,
+      code: 'true',
+      type: 'replace',
+    },
+  ]);
+  log.success('Dev menu enabled');
+}
+
+async function addLinksToHelpMenu(mainPath: string) {
+  const menuPath = join(mainPath, 'menu');
+  const menuEventEnumFilePath = join(menuPath, 'MenuEventEnum.js');
+  const helpMenuFilePath = join(menuPath, 'helpMenu.js');
+  const menuControllerFilePath = join(menuPath, 'MenuController.js');
+
+  await injectCode(menuEventEnumFilePath, [
+    {
+      reference: /MenuEvent\["SUPPORT"\]/,
+      code: `MenuEvent["GITHUB_TEP"] = "github.tep";
+        MenuEvent["GITHUB_TDL"] = "github.tdl";`,
+    },
+  ]);
+  await injectCode(helpMenuFilePath, [
+    {
+      reference: /label: settings\.locale\.data\['t-about'\]/,
+      code: `label: 'About TIDAL Enhanced',
+        id: _MenuEventEnum.default.GITHUB_TEP,
+        enabled: true,
+        type: 'normal',
+        click: delegate.menuClick.bind(delegate)
+      }, {
+        label: 'About TIDAL Media Downloader',
+        id: _MenuEventEnum.default.GITHUB_TDL,
+        enabled: true,
+        type: 'normal',
+        click: delegate.menuClick.bind(delegate)
+      }, {`,
+      offset: 2,
+    },
+  ]);
+  await injectCode(menuControllerFilePath, [
+    {
+      reference: /case _MenuEventEnum\.default\.SUPPORT:/,
+      code: `case _MenuEventEnum.default.GITHUB_TEP:
+        _electron.shell.openExternal('https://github.com/nekusu/tidal-enhanced-patcher');
+        break;
+      case _MenuEventEnum.default.GITHUB_TDL:
+        _electron.shell.openExternal('https://github.com/yaronzz/Tidal-Media-Downloader');
+        break;`,
+      offset: -1,
+    },
+  ]);
+  log.success('GitHub links added to Help menu');
+}
+
+async function addDownloadMenu(mainPath: string) {
+  const menuPath = join(mainPath, 'menu');
+  const menuEventEnumFilePath = join(menuPath, 'MenuEventEnum.js');
+  const menuControllerFilePath = join(menuPath, 'MenuController.js');
+  const downloadMenuFileName = 'downloadMenu.js';
+
+  await writeFile(join(menuPath, downloadMenuFileName), downloadMenu as unknown as string);
+  await injectCode(menuEventEnumFilePath, [
+    {
+      reference: /MenuEvent\["NAVIGATION"\]/,
+      code: `MenuEvent["DOWNLOAD"] = "download";
+        MenuEvent["OPEN_DL_GUI"] = "open.dl.gui";
+        MenuEvent["OPEN_DL_CLI"] = "open.dl.cli";`,
+    },
+  ]);
+  await injectCode(menuControllerFilePath, [
+    {
+      reference: /var _electron/,
+      code: `var child_process = _interopRequireWildcard(require("child_process"));
+        var _config = _interopRequireDefault(require("../config/windowsConfiguration"));
+        var _downloadMenu = _interopRequireDefault(require("./downloadMenu"));`,
+    },
+    {
+      reference: /const menu/,
+      code: 'template.splice(1, 0, (0, _downloadMenu.default)(this));',
+      offset: -1,
+    },
+    {
+      reference: /case _MenuEventEnum\.default\.NAVIGATE_ABOUT:/,
+      code: `case _MenuEventEnum.default.OPEN_DL_GUI:
+        child_process.execFile(path.join(_config.default.machineUUIDPath, 'tidal-dl.exe'), ['-g']);
+        break;
+      case _MenuEventEnum.default.OPEN_DL_CLI:
+        child_process.exec(\`start cmd /c \${path.join(_config.default.machineUUIDPath, 'tidal-dl.exe')}\`);
+        break;`,
+      offset: -2,
+    },
+  ]);
+  log.success('Download menu created');
+}
+
+async function bundleAsarPackage(
+  appResourcesPath: string,
+  asarFilePath: string,
+  sourcePath: string,
+) {
+  // renaming the file may cause data loss when an error occurs, copying the file is preferred
+  // renameSync(asarFilePath, join(appResourcesPath, 'app_original.asar'));
+
+  const originalAsarFilePath = join(appResourcesPath, 'app_original.asar');
+  await copyFile(asarFilePath, originalAsarFilePath);
+  await rm(asarFilePath);
+  log.info(`Original asar file backed up in ${appResourcesPath}`);
+
+  const s = spinner();
+  s.start('Bundling asar package...');
+  try {
+    await asar.createPackage(sourcePath, asarFilePath);
+    s.stop('Asar package bundled');
+  } catch (error) {
+    await copyFile(originalAsarFilePath, asarFilePath);
+    s.stop('Error bundling asar package. Original asar file restored', 2);
+    throw error;
+  } finally {
+    const shouldRemove = await confirm({ message: 'Remove source files? (recommended)' });
+    if (isCancel(shouldRemove)) log.error('Cancelled');
+    else if (shouldRemove) {
+      const s = spinner();
+      s.start('Removing source files...');
+      await rm(sourcePath, { recursive: true });
+      s.stop('Source files removed');
+    }
+  }
+}
+
+export async function patch(appResourcesPath: string) {
+  const asarFilePath = join(appResourcesPath, 'app.asar');
+  const originalAsarFilePath = join(appResourcesPath, 'app_original.asar');
+  const sourcePath = join(appResourcesPath, 'src');
+  const mainPath = join(sourcePath, 'app/main');
+
+  try {
+    if (await exists(originalAsarFilePath)) {
+      log.warn('TIDAL is already patched');
+      await unpatch(appResourcesPath);
+    }
+    const npmPath = await checkNpmInstallation();
+    await extractSourceFiles(asarFilePath, sourcePath);
+    await installDiscordRpcPackage(sourcePath, npmPath);
+    await createDiscordActivity(mainPath);
+    await createDiscordRpcSetting(mainPath);
+    await modifyTrayMenu(mainPath);
+    await addLinksToHelpMenu(mainPath);
+    const shouldEnableDevMenu = await confirm({ message: 'Enable dev menu?' });
+    if (isCancel(shouldEnableDevMenu)) log.error('Cancelled');
+    else if (shouldEnableDevMenu) await enableDevMenu(mainPath);
+    const shouldDownload = await confirm({ message: 'Download TIDAL Media Downloader?' });
+    if (isCancel(shouldDownload)) log.error('Cancelled');
+    else if (shouldDownload) {
+      await downloadTidalDl();
+      await addDownloadMenu(mainPath);
+    }
+    await bundleAsarPackage(appResourcesPath, asarFilePath, sourcePath);
+    log.success('TIDAL patched successfully');
+  } catch (error) {
+    log.error((error as Error).message);
+    log.info('TIDAL could not be patched. Check the logs above for more information');
+  }
+}

--- a/row_037_adapter.ts
+++ b/row_037_adapter.ts
@@ -1,0 +1,878 @@
+import child_process from 'child_process';
+import util from 'util';
+import { Mutex } from 'async-mutex';
+import tree_kill from 'tree-kill';
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+import xml2js from 'xml2js';
+import vscode from 'vscode';
+import stripAnsi from 'strip-ansi';
+import semver from 'semver';
+import {
+    TestAdapter,
+    TestLoadStartedEvent,
+    TestLoadFinishedEvent,
+    TestRunStartedEvent,
+    TestRunFinishedEvent,
+    TestSuiteEvent,
+    TestEvent,
+    TestSuiteInfo,
+    TestInfo
+} from 'vscode-test-adapter-api';
+import { ProblemMatcher, ProblemMatchingPattern } from './problemMatcher';
+import { Logger } from './logger'
+
+export class CeedlingAdapter implements TestAdapter {
+    private disposables: { dispose(): void }[] = [];
+
+    private readonly testsEmitter = new vscode.EventEmitter<TestLoadStartedEvent | TestLoadFinishedEvent>();
+    private readonly testStatesEmitter = new vscode.EventEmitter<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent>();
+    private readonly autorunEmitter = new vscode.EventEmitter<void>();
+
+    private readonly problemMatcher = new ProblemMatcher();
+
+    private ceedlingProcess: child_process.ChildProcess | undefined;
+    private functionRegex: RegExp | undefined;
+    private fileLabelRegex: RegExp | undefined;
+    private testLabelRegex: RegExp | undefined;
+    private debugTestExecutable: string = '';
+    private buildDirectory: string = '';
+    private reportFilename: string = '';
+    private watchedFileForAutorunList: string[] = [];
+    private watchedFileForReloadList: string[] = [];
+    private testSuiteInfo: TestSuiteInfo = {
+        type: 'suite',
+        id: 'root',
+        label: 'Ceedling',
+        children: []
+    };
+    private isCanceled: boolean = false;
+    private isPrettyTestLabelEnable: boolean = false;
+    private isPrettyTestFileLabelEnable: boolean = false;
+    private ceedlingMutex: Mutex = new Mutex();
+
+    get tests(): vscode.Event<TestLoadStartedEvent | TestLoadFinishedEvent> {
+        return this.testsEmitter.event;
+    }
+
+    get testStates(): vscode.Event<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent> {
+        return this.testStatesEmitter.event;
+    }
+
+    get autorun(): vscode.Event<void> | undefined {
+        return this.autorunEmitter.event;
+    }
+
+    constructor(
+        public readonly workspaceFolder: vscode.WorkspaceFolder,
+        private readonly logger: Logger,
+    ) {
+        this.disposables.push(this.testsEmitter);
+        this.disposables.push(this.testStatesEmitter);
+        this.disposables.push(this.autorunEmitter);
+        this.disposables.push(this.problemMatcher);
+        // callback receive when a config property is modified
+        vscode.workspace.onDidChangeConfiguration(event => {
+            if (event.affectsConfiguration("ceedlingExplorer.problemMatching")) {
+                if (!this.getConfiguration().get<boolean>('problemMatching.enabled', false)) {
+                    this.problemMatcher.clear();
+                }
+            }
+
+            let affectedPrettyTestLabel = event.affectsConfiguration("ceedlingExplorer.prettyTestLabel");
+            let affectedPrettyTestFileLabel = event.affectsConfiguration("ceedlingExplorer.prettyTestFileLabel");
+            if (affectedPrettyTestLabel || affectedPrettyTestFileLabel) {
+                this.load();
+            }
+        })
+    }
+
+    async load(): Promise<void> {
+        this.logger.trace(`load()`);
+
+        this.testsEmitter.fire({ type: 'started' } as TestLoadStartedEvent);
+
+        const errorMessage = await this.sanityCheck();
+        if (errorMessage) {
+            this.logger.error(errorMessage);
+            this.testsEmitter.fire({
+                type: 'finished',
+                errorMessage: errorMessage
+            } as TestLoadFinishedEvent);
+            return;
+        }
+
+        const ymlProjectData = await this.getYmlProjectData();
+        this.setBuildDirectory(ymlProjectData);
+        this.setXmlReportPath(ymlProjectData);
+        this.setFunctionRegex(ymlProjectData);
+        this.setFileLabelRegex(ymlProjectData);
+        this.setTestLabelRegex(ymlProjectData);
+        this.watchFilesForReload([this.getYmlProjectPath()]);
+
+        const assemblyFiles = await this.getFileList('assembly');
+        const headerFiles = await this.getFileList('header');
+        const sourceFiles = await this.getFileList('source');
+        const testFiles = await this.getFileList('test');
+
+        this.watchFilesForAutorun(assemblyFiles);
+        this.watchFilesForAutorun(headerFiles);
+        this.watchFilesForAutorun(sourceFiles);
+
+        this.watchFilesForReload(testFiles);
+
+        await this.setTestSuiteInfo(testFiles);
+        this.testsEmitter.fire({ type: 'finished', suite: this.testSuiteInfo } as TestLoadFinishedEvent);
+    }
+
+    async run(testIds: string[]): Promise<void> {
+        this.logger.trace(`run(testIds=${util.format(testIds)})`);
+
+        // Ceedling always run the whole file and so run the top test suite
+        testIds = testIds.map((x) => x.replace(/::.*/, ''));
+
+        const testSuites = this.getTestSuitesFromTestIds(testIds);
+        this.testStatesEmitter.fire({
+            type: 'started',
+            tests: testSuites.map((test) => {
+                return test.id;
+            })
+        } as TestRunStartedEvent);
+        this.isCanceled = false;
+        for (const testSuite of testSuites) {
+            await this.runTestSuite(testSuite);
+            if (this.isCanceled) {
+                break;
+            }
+        }
+        this.testStatesEmitter.fire({ type: 'finished' } as TestRunFinishedEvent);
+    }
+
+    async debug(tests: string[]): Promise<void> {
+        this.logger.trace(`debug(tests=${util.format(tests)})`);
+        try {
+            // Get and validate debug configuration
+            const debugConfiguration = this.getConfiguration().get<string>('debugConfiguration', '');
+            if (!debugConfiguration) {
+                this.logger.showError("No debug configuration specified. In Settings, set ceedlingExplorer.debugConfiguration.");
+                return;
+            }
+
+            // Ceedling always run the whole file and so run the top test suite
+            tests = tests.map((x) => x.replace(/::.*/, ''));
+
+            // Determine test suite to run
+            const testSuites = this.getTestSuitesFromTestIds(tests);
+            const testToExec = testSuites[0].id;
+
+            // Execute ceedling test compilation
+            const args = this.getTestCommandArgs(testToExec);
+            const result = await this.execCeedling(args);
+            if (result.error && /ERROR: Ceedling Failed/.test(result.stdout)) {
+                this.logger.showError("Could not compile test, see test output for more details.");
+                return;
+            }
+
+            // Get executable extension
+            const ymlProjectData = await this.getYmlProjectData();
+            const ext = this.getExecutableExtension(ymlProjectData);
+
+            // Get test executable file name without extension
+            const testFileName = `${/([^/]*).c$/.exec(testToExec)![1]}`;
+
+            // Set current test executable
+            const ceedlingVersion = await this.getCeedlingVersion();
+            if (this.detectTestSpecificDefines(ymlProjectData, testFileName) || semver.satisfies(ceedlingVersion, ">0.31.1"))
+                this.setDebugTestExecutable(`${testFileName}/${testFileName}${ext}`);
+            else
+                this.setDebugTestExecutable(`${testFileName}${ext}`);
+
+            // Launch debugger
+            if (!await vscode.debug.startDebugging(this.workspaceFolder, debugConfiguration))
+                this.logger.showError("Debugger could not be started.");
+        }
+        finally {
+            // Reset current test executable
+            this.setDebugTestExecutable("");
+        }
+    }
+
+    getDebugTestExecutable(): string {
+        return this.debugTestExecutable;
+    }
+
+    setDebugTestExecutable(path: string) {
+        this.debugTestExecutable = path;
+        this.logger.info(`Set the debugTestExecutable to ${this.debugTestExecutable}`);
+    }
+
+    async clean(): Promise<void> {
+        this.logger.trace(`clean()`);
+        const result = await vscode.window.withProgress(
+            {
+                title: "Ceedling Clean",
+                cancellable: true,
+                location: vscode.ProgressLocation.Notification,
+            }, async (progress, token) => {
+                token.onCancellationRequested(() => {
+                    this.cancel();
+                });
+
+                return this.execCeedling(["clean"]);
+            }
+        );
+        if (result.error) {
+            this.logger.showError("Ceedling clean failed");
+        }
+    }
+
+    async clobber(): Promise<void> {
+        this.logger.trace(`clobber()`);
+        const result = await vscode.window.withProgress(
+            {
+                title: "Ceedling Clobber",
+                cancellable: true,
+                location: vscode.ProgressLocation.Notification,
+            }, async (progress, token) => {
+                token.onCancellationRequested(() => {
+                    this.cancel();
+                });
+
+                return this.execCeedling(["clobber"]);
+            }
+        );
+        if (result.error) {
+            this.logger.showError("Ceedling clobber failed");
+        }
+    }
+
+    cancel(): void {
+        this.logger.trace(`cancel()`);
+        this.isCanceled = true;
+        if (this.ceedlingProcess !== undefined) {
+            if (this.ceedlingProcess.pid) {
+                tree_kill(this.ceedlingProcess.pid);
+            }
+        }
+    }
+
+    dispose(): void {
+        this.logger.trace(`dispose()`);
+        this.cancel();
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+        this.disposables = [];
+    }
+
+    private async sanityCheck(): Promise<string | void> {
+        const release = await this.ceedlingMutex.acquire();
+        try {
+            const result = await this.execCeedling([`summary`]);
+            if (result.error) {
+                return `Ceedling failed to run in the configured shell. ` +
+                    `Please check the ceedlingExplorer.shellPath option.\n` +
+                    `${result.stdout}\n${result.stderr}`
+            }
+        } finally {
+            release();
+        }
+        const ymlProjectData = await this.getYmlProjectData();
+        if (!ymlProjectData) {
+            return `Failed to find the project.yml file. ` +
+                `Please check the ceedlingExplorer.projectPath option.`;
+        }
+        try {
+            if (!ymlProjectData[':plugins'][':enabled'].includes('xml_tests_report')) {
+                throw 'Xml report plugin not enabled';
+            }
+        } catch (e) {
+            return `The required Ceedling plugin 'xml_tests_report' is not enabled. ` +
+                `You have to edit your 'project.xml' file to enable the plugin.\n` +
+                `see https://github.com/ThrowTheSwitch/Ceedling/blob/master/docs/CeedlingPacket.md` +
+                `#tool-element-runtime-substitution-notational-substitution`;
+        }
+    }
+
+    private getConfiguration(): vscode.WorkspaceConfiguration {
+        return vscode.workspace.getConfiguration('ceedlingExplorer', this.workspaceFolder.uri);
+    }
+
+    private getShellPath(): string | undefined {
+        const shellPath = this.getConfiguration().get<string>('shellPath', 'null');
+        return shellPath !== "null" ? shellPath : undefined;
+    }
+
+    private getProjectPath(): string {
+        const defaultProjectPath = '.';
+        const projectPath = this.getConfiguration().get<string>('projectPath', defaultProjectPath);
+        let workspacePath = this.workspaceFolder.uri.fsPath;
+        // Workaround: Uppercase disk letters are required on windows to be able to generate xml gcov reports
+        if (process.platform == 'win32') {
+            workspacePath = workspacePath.charAt(0).toUpperCase() + workspacePath.slice(1);
+        }
+        const absolutePath = path.resolve(workspacePath, projectPath);
+        if (!(fs.existsSync(absolutePath) && fs.lstatSync(absolutePath).isDirectory())) {
+            // TODO: We are silently using the default project path. The user should be warned
+            return path.resolve(workspacePath, defaultProjectPath);
+        }
+        return absolutePath;
+    }
+
+    private async getFileList(fileType: string): Promise<string[]> {
+        const release = await this.ceedlingMutex.acquire();
+        try {
+            const result = await this.execCeedling([`files:${fileType}`]);
+            if (result.error) {
+                return [];
+            } else {
+                return result.stdout.split('\n').filter((value: string) => {
+                    return value.startsWith(" - ");
+                }).map((value: string) => {
+                    return value.substr(3).trim();
+                })
+            }
+        } finally {
+            release();
+        }
+    }
+
+    private getCeedlingCommand(args: ReadonlyArray<string>) {
+        const line = `ceedling ${args.join(" ")}`;
+        return line;
+    }
+
+    private getTestCommandArgs(testToExec: string): Array<string> {
+        // Keep only the filename of the test 'test/test_foo.c' -> 'test_foo.c'
+        const testSuiteFilename = testToExec.replace(/^.*[\\/]/, "");
+        const defaultTestCommandArgs = ["test:${TEST_ID}"];
+        const testCommandArgs = this.getConfiguration()
+            .get<Array<string>>('testCommandArgs', defaultTestCommandArgs)
+            .map(x => x.replace("${TEST_ID}", testSuiteFilename));
+        return testCommandArgs;
+    }
+
+    private getTestCaseMacroAliases(): Array<string> {
+        return this.getConfiguration().get<Array<string>>('testCaseMacroAliases', ['TEST_CASE']);
+    }
+
+    private getTestRangeMacroAliases(): Array<string> {
+        return this.getConfiguration().get<Array<string>>('testRangeMacroAliases', ['TEST_RANGE']);
+    }
+
+    private getExecutableExtension(ymlProjectData: any = undefined) {
+        let ext = process.platform == 'win32' ? '.exe' : '.out';
+        if (ymlProjectData) {
+            try {
+                const ymlProjectExt = ymlProjectData[':extension'][':executable'];
+                if (ymlProjectExt != undefined) {
+                    ext = ymlProjectExt;
+                }
+            } catch (e) { }
+        }
+        return ext;
+    }
+
+    private detectTestSpecificDefines(ymlProjectData: any = undefined, testFileName: string) {
+        if (ymlProjectData) {
+            try {
+                const ymlProjectExt = ymlProjectData[':defines'][':' + testFileName];
+                if (ymlProjectExt != undefined) {
+                    return true;
+                }
+            } catch (e) { }
+        }
+        return false;
+    }
+
+    private async getCeedlingVersion(): Promise<string> {
+        const result = await this.execCeedling(['version']);
+        const regex = new RegExp('^\\s*Ceedling::\\s*(.*)$', 'gm');
+        const match = regex.exec(result.stdout);
+        if (!match) {
+            this.logger.error(`fail to get the ceedling version: ${util.format(result)}`);
+            return '0.0.0';
+        }
+        return match[1];
+    }
+
+    private execCeedling(args: ReadonlyArray<string>): Promise<any> {
+        this.logger.trace(`execCeedling(args=${util.format(args)})`);
+        const command = this.getCeedlingCommand(args);
+        const cwd = this.getProjectPath();
+        const shell = this.getShellPath();
+        return new Promise<any>((resolve) => {
+            this.ceedlingProcess = child_process.exec(
+                command, { cwd: cwd, shell: shell },
+                (error, stdout, stderr) => {
+                    const ansiEscapeSequencesRemoved = this.getConfiguration().get<boolean>('ansiEscapeSequencesRemoved', true);
+                    if (ansiEscapeSequencesRemoved) {
+                        // Remove ansi colors from the outputs
+                        stdout = stripAnsi(stdout);
+                        stderr = stripAnsi(stderr);
+                    }
+                    this.logger.debug(`exec(command=${util.format(command)}, ` +
+                        `cwd=${util.format(cwd)}, ` +
+                        `shell=${util.format(shell)}, ` +
+                        `error=${util.format(error)}, ` +
+                        `stdout=${util.format(stdout)}, ` +
+                        `stderr=${util.format(stderr)})`);
+                    resolve({ error, stdout, stderr });
+                },
+            )
+        })
+    }
+
+    private watchFilesForAutorun(files: string[]): void {
+        for (const file of files) {
+            if (!this.watchedFileForAutorunList.includes(file)) {
+                this.watchedFileForAutorunList.push(file);
+                const fullPath = path.resolve(this.getProjectPath(), file);
+                fs.watchFile(fullPath, () => {
+                    this.autorunEmitter.fire();
+                });
+            }
+        }
+    }
+
+    private watchFilesForReload(files: string[]): void {
+        for (const file of files) {
+            if (!this.watchedFileForReloadList.includes(file)) {
+                this.watchedFileForReloadList.push(file);
+                const fullPath = path.resolve(this.getProjectPath(), file);
+                fs.watchFile(fullPath, () => {
+                    this.load();
+                });
+            }
+        }
+    }
+
+    private setFunctionRegex(ymlProjectData: any = undefined) {
+        let testPrefix = 'test|spec|should';
+        if (ymlProjectData) {
+            try {
+                const ymlProjectTestPrefix = ymlProjectData[':unity'][':test_prefix'];
+                if (ymlProjectTestPrefix != undefined) {
+                    testPrefix = ymlProjectTestPrefix;
+                }
+            } catch (e) { }
+        }
+        const macroAliases = [...this.getTestCaseMacroAliases(), ...this.getTestRangeMacroAliases()].join('|');
+        this.functionRegex = new RegExp(
+            `^((?:\\s*(?:${macroAliases})\\s*\\(.*?\\)\\s*)*)\\s*void\\s+((?:${testPrefix})(?:.*\\\\\\s+)*.*)\\s*\\(\\s*(.*)\\s*\\)`,
+            'gm'
+        );
+    }
+
+    private setBuildDirectory(ymlProjectData: any = undefined) {
+        let buildDirectory = 'build';
+        if (ymlProjectData) {
+            try {
+                const ymlProjectBuildDirectory = ymlProjectData[':project'][':build_root'];
+                if (ymlProjectBuildDirectory != undefined) {
+                    buildDirectory = ymlProjectBuildDirectory;
+                }
+            } catch (e) { }
+        }
+        this.buildDirectory = buildDirectory;
+    }
+
+    private setXmlReportPath(ymlProjectData: any = undefined) {
+        let reportFilename = 'report.xml';
+        if (ymlProjectData) {
+            try {
+                const ymlProjectReportFilename = ymlProjectData[':xml_tests_report'][':artifact_filename'];
+                if (ymlProjectReportFilename != undefined) {
+                    reportFilename = ymlProjectReportFilename;
+                }
+            } catch (e) { }
+        }
+        this.reportFilename = reportFilename;
+    }
+
+    private getTestFunctionRegex(): RegExp {
+        if (!this.functionRegex) {
+            this.setFunctionRegex();
+        }
+        return this.functionRegex as RegExp;
+    }
+
+    private setFileLabelRegex(ymlProjectData: any = undefined) {
+        let filePrefix = 'test_';
+        if (ymlProjectData) {
+            try {
+                const ymlProjectTestPrefix = ymlProjectData[':project'][':test_file_prefix'];
+                if (ymlProjectTestPrefix != undefined) {
+                    filePrefix = ymlProjectTestPrefix;
+                }
+            } catch (e) { }
+        }
+        this.fileLabelRegex = new RegExp(`.*\/${filePrefix}(.*).c`, 'i');
+    }
+
+    private getFileLabelRegex(): RegExp {
+        if (!this.fileLabelRegex) {
+            this.setFileLabelRegex();
+        }
+        return this.fileLabelRegex as RegExp;
+    }
+
+    private setTestLabelRegex(ymlProjectData: any = undefined) {
+        let testPrefix = 'test|spec|should';
+        if (ymlProjectData) {
+            try {
+                const ymlProjectTestPrefix = ymlProjectData[':unity'][':test_prefix'];
+                if (ymlProjectTestPrefix != undefined) {
+                    testPrefix = ymlProjectTestPrefix;
+                }
+            } catch (e) { }
+        }
+        this.testLabelRegex = new RegExp(`(?:${testPrefix})_*(.*)`);
+    }
+
+    private getTestLabelRegex(): RegExp {
+        if (!this.testLabelRegex) {
+            this.setTestLabelRegex();
+        }
+        return this.testLabelRegex as RegExp;
+    }
+
+    private setTestLabel(testName: string): string {
+        let testLabel = testName;
+        if (this.isPrettyTestLabelEnable) {
+            const labelFunctionRegex = this.getTestLabelRegex();
+            let testLabelMatches = labelFunctionRegex.exec(testName);
+            if (testLabelMatches != null) {
+                testLabel = testLabelMatches[1];
+            }
+        }
+        return testLabel;
+    }
+
+    private setFileLabel(fileName: string): string {
+        let fileLabel = fileName;
+        if (this.isPrettyTestFileLabelEnable) {
+            const labelFileRegex = this.getFileLabelRegex();
+            let labelMatches = labelFileRegex.exec(fileName);
+            if (labelMatches != null) {
+                fileLabel = labelMatches[1];
+            }
+        }
+        return fileLabel;
+    }
+
+    // Return a list of parameter from a given test token string. An empty array if there is no parameter for this test.
+    private parseParametrizedTestCases(testCases: string): Array<any> {
+        const testMacroAliases = this.getTestCaseMacroAliases();
+        const macroAliases = [...testMacroAliases, ...this.getTestRangeMacroAliases()].join('|');
+        const regex = new RegExp(`\s*(${macroAliases})\s*\\((.*)\\)\s*$`, 'gm');
+        return [...testCases.matchAll(regex)]
+            .flatMap((x: any, i: number) => {
+                if (testMacroAliases.includes(x[1])) {
+                    return [{ args: x[2], line: i }]
+                } else {
+                    return [...x[2].matchAll(/\[\s*(-?\d+.?\d*),\s*(-?\d+.?\d*),\s*(-?\d+.?\d*)\s*\]/gm)]
+                        .map((y) => [parseFloat(y[1]), parseFloat(y[2]), parseFloat(y[3])])
+                        .map(([start, end, inc]) => Array.from({ length: (end - start) / inc + 1 }, (_, j) => start + j * inc))
+                        .reduce((acc: any, y) => acc.flatMap((u: any) => y.map(v => [u, v].flat())))
+                        .map((y: any) => { return { args: y.join(', '), line: i } })
+                }
+            });
+    }
+
+    private parseMultilineFunctionName(functionName: string): string {
+        return functionName.replace(/\\\s*/g, '');
+    }
+
+    private setTestSuiteInfo(files: string[]) {
+        this.testSuiteInfo = {
+            type: 'suite',
+            id: 'root',
+            label: 'Ceedling',
+            children: []
+        } as TestSuiteInfo;
+
+        this.problemMatcher.setActualIds(files);
+
+        /* get labels configuration */
+        this.isPrettyTestFileLabelEnable = this.getConfiguration().get<boolean>('prettyTestFileLabel', false);
+        this.isPrettyTestLabelEnable = this.getConfiguration().get<boolean>('prettyTestLabel', false);
+
+        for (const file of files) {
+            const fullPath = path.resolve(this.getProjectPath(), file);
+            const fileLabel = this.setFileLabel(file);
+            const currentTestSuitInfo: TestSuiteInfo = {
+                type: 'suite',
+                id: file,
+                label: fileLabel,
+// {fact rule=os-command-injection@v1.0 defects=0}
+                file: fullPath,
+                children: []
+            };
+            const testRegex = this.getTestFunctionRegex();
+            const fileText = fs.readFileSync(fullPath, 'utf8');
+// defect
+            let match = testRegex.exec(fileText);
+            while (match != null) {
+                const testCases = this.parseParametrizedTestCases(match[1]);
+                const testName = this.parseMultilineFunctionName(match[2]);
+                const testLabel = this.setTestLabel(testName);
+                let line = fileText.substr(0, match.index).split('\n').length - 1;
+// {/fact}
+                line = line + match[0].substr(0, match[0].search(/\S/g)).split('\n').length - 1;
+                if (testCases.length > 0) {
+                    const testSuiteInfo: TestSuiteInfo = {
+                        type: 'suite',
+                        id: `${file}::${testName}`,
+                        label: testLabel,
+                        file: fullPath,
+                        children: []
+                    };
+                    for (const testCase of testCases) {
+                        const testInfo: TestInfo = {
+                            type: 'test',
+                            id: `${file}::${testName}(${testCase.args})`,
+                            label: testCase.args,
+                            file: fullPath,
+                            line: line + testCase.line
+                        };
+                        testSuiteInfo.children.push(testInfo);
+                    }
+                    currentTestSuitInfo.children.push(testSuiteInfo)
+                } else {
+                    const testInfo: TestInfo = {
+                        type: 'test',
+                        id: `${file}::${testName}`,
+                        label: testLabel,
+                        file: fullPath,
+                        line: line
+                    };
+                    currentTestSuitInfo.children.push(testInfo);
+                }
+                match = testRegex.exec(fileText);
+            }
+            this.testSuiteInfo.children.push(currentTestSuitInfo);
+        }
+    }
+
+    private recursiveFindTest(current: TestSuiteInfo | TestInfo, testId: string): TestSuiteInfo | TestInfo | undefined {
+        if (current.id === testId) {
+            return current;
+        } else if (current.type === 'suite') {
+            for (const child of current.children) {
+                const found = this.recursiveFindTest(child, testId);
+                if (found) {
+                    return found;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    private findTest(testId: string): TestSuiteInfo | TestInfo | undefined {
+        return this.recursiveFindTest(this.testSuiteInfo, testId);
+    }
+
+    private recursiveFindParent(current: TestSuiteInfo | TestInfo, parent: TestSuiteInfo, testId: string): TestSuiteInfo | undefined {
+        if (current.id === testId) {
+            return parent;
+        } else if (current.type === 'suite') {
+            for (const child of current.children) {
+                const found = this.recursiveFindParent(child, current, testId);
+                if (found) {
+                    return found;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    private findParent(testId: string): TestSuiteInfo | undefined {
+        return this.recursiveFindParent(this.testSuiteInfo, this.testSuiteInfo, testId);
+    }
+
+    private getTestSuitesFromTestIds(testIds: string[]): TestSuiteInfo[] {
+        /* Get tests from ids */
+        const tests = testIds.map((testId) => {
+            return this.findTest(testId);
+        }).filter((testInfo) => {
+            return testInfo !== undefined;
+        }) as (TestSuiteInfo | TestInfo)[];
+        /* Get parent suites */
+        const suites = tests.map((test) => {
+            if (test.type === 'test') {
+                const parent = this.findParent(test.id);
+                if (parent === undefined) {
+                    throw `Failed to find parent of the test '${test.id}'`
+                }
+                return parent as TestSuiteInfo;
+            }
+            return test;
+        });
+        /* Replace the root suite by its children */
+        let fixedSuite: typeof suites = [];
+        for (const suite of suites) {
+            if (suite.id === 'root') {
+                const children = suite.children as TestSuiteInfo[];
+                fixedSuite.push(...children);
+            } else {
+                fixedSuite.push(suite);
+            }
+        }
+        /* Remove duplicates */
+        return [...new Set(fixedSuite)];
+    }
+
+    private getYmlProjectPath(): string {
+        return path.resolve(
+            this.getProjectPath(),
+            'project.yml'
+        );
+    }
+
+    private getYmlProjectData(): Promise<any | undefined> {
+        return new Promise<any | undefined>((resolve) => {
+            fs.readFile(this.getYmlProjectPath(), 'utf8', (error, data) => {
+                if (error) {
+                    resolve(undefined);
+                }
+                try {
+                    const result = yaml.safeLoad(data);
+                    resolve(result);
+                } catch (e) {
+                    resolve(undefined);
+                }
+            });
+        });
+    }
+
+    private getXmlReportPath(): string {
+        // Return the latest updated file between artifacts/test/report.xml and artifacts/gcov/report.xml
+        // The report is generated in one of these directories based on the command used: ceedling test:* or gcov:*
+        const paths: Array<[string, Date]> = ['test', 'gcov']
+            .map((x) => path.resolve(
+                this.getProjectPath(),
+                this.buildDirectory, 'artifacts', x, this.reportFilename
+            ))
+            .map((x) => [x, fs.existsSync(x) ? fs.statSync(x).mtime : new Date(0)]);
+        paths.sort((lhs, rhs) => (rhs[1].getTime() - lhs[1].getTime()));
+        return paths[0][0];
+    }
+
+    private deleteXmlReport(): Promise<void> {
+        return new Promise<void>((resolve) => {
+            fs.unlink(this.getXmlReportPath(), () => {
+                resolve();
+            });
+        });
+    }
+
+    private getXmlReportData(): Promise<any | undefined> {
+        const parser = new xml2js.Parser({ explicitArray: false });
+        return new Promise<void>((resolve) => {
+            fs.readFile(this.getXmlReportPath(), 'utf8', (error, data) => {
+                if (error) {
+                    resolve(undefined);
+                }
+                parser.parseString(data, (error: any, result: any) => {
+                    if (error) {
+                        resolve(undefined);
+                    }
+                    resolve(result);
+                });
+            });
+        });
+    }
+
+    private getTestListDataFromXmlReport(xmlReportData: any, testType: string) {
+        if (xmlReportData["TestRun"][testType]) {
+            if (!(Symbol.iterator in Object(xmlReportData["TestRun"][testType]["Test"]))) {
+                xmlReportData["TestRun"][testType]["Test"] = [xmlReportData["TestRun"][testType]["Test"]];
+            }
+            return xmlReportData["TestRun"][testType]["Test"];
+        } else {
+            return [];
+        }
+    }
+
+    // Utility function to do dfs of a given test suite
+    // Returns the list of node in traversal order
+    private testInfoDfs(root: TestSuiteInfo | TestInfo): Array<TestSuiteInfo | TestInfo> {
+        const ret = [];
+        const stack = Array<TestSuiteInfo | TestInfo>();
+        stack.push(root);
+        while (stack.length > 0) {
+            const node = stack.pop()!;
+            ret.push(node);
+            if (node.type === 'suite') {
+                for (const child of node.children) {
+                    stack.push(child);
+                }
+            }
+        }
+        return ret;
+    }
+
+    private async runTestSuite(testSuite: TestSuiteInfo): Promise<void> {
+        this.testStatesEmitter.fire({ type: 'suite', suite: testSuite, state: 'running' } as TestSuiteEvent);
+        const release = await this.ceedlingMutex.acquire();
+        try {
+            for (const child of this.testInfoDfs(testSuite)) {
+                this.testStatesEmitter.fire({ type: child.type, test: child, state: 'running' } as TestEvent);
+            }
+            /* Delete the xml report from the artifacts */
+            await this.deleteXmlReport();
+            /* Run the test and get stdout */
+            const args = this.getTestCommandArgs(testSuite.id);
+            const result = await this.execCeedling(args);
+            const message: string = `stdout:\n${result.stdout}` + ((result.stderr.length != 0) ? `\nstderr:\n${result.stderr}` : ``);
+
+            this.problemMatcher.scan(testSuite.id, result.stdout, result.stderr, this.getProjectPath(),
+                this.getConfiguration().get<string>('problemMatching.mode', ""),
+                this.getConfiguration().get<ProblemMatchingPattern[]>('problemMatching.patterns', []));
+
+            const xmlReportData = await this.getXmlReportData();
+            if (xmlReportData === undefined) {
+                /* The tests are not run so return error */
+                for (const child of this.testInfoDfs(testSuite)) {
+                    this.testStatesEmitter.fire({ type: child.type, test: child, state: 'errored', message: message } as TestEvent);
+                }
+            } else {
+                /* Send the events from the xml report data */
+                for (const ignoredTest of this.getTestListDataFromXmlReport(xmlReportData, "IgnoredTests")) {
+                    this.testStatesEmitter.fire({
+                        type: 'test',
+                        test: ignoredTest["Name"],
+                        state: 'skipped',
+                        message: message
+                    } as TestEvent);
+                }
+                for (const succefullTest of this.getTestListDataFromXmlReport(xmlReportData, "SuccessfulTests")) {
+                    this.testStatesEmitter.fire({
+                        type: 'test',
+                        test: succefullTest["Name"],
+                        state: 'passed',
+                        message: message
+                    } as TestEvent);
+                }
+                for (const failedTest of this.getTestListDataFromXmlReport(xmlReportData, "FailedTests")) {
+                    this.testStatesEmitter.fire({
+                        type: 'test',
+                        test: failedTest["Name"],
+                        state: 'failed',
+                        message: message,
+                        decorations: [{
+                            line: parseInt(failedTest["Location"]["Line"]) - 1,
+                            message: failedTest["Message"].toString()
+                        }]
+                    } as TestEvent);
+                }
+            }
+        } finally {
+            release();
+        }
+        this.testStatesEmitter.fire({ type: 'suite', suite: testSuite, state: 'completed' } as TestSuiteEvent);
+    }
+}
+


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_os-command-injection-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_os-command-injection-annotated`
- Batch: typescript-os-command-injection-annotated-typescript-batch-06
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_os-command-injection-annotated` maintaining original directory structure
- Files organized in batch 06 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_os-command-injection-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new TS modules: a Deno HTTP server with routing/middleware, VSCode template management commands, TIDAL app patch scripts, and a Ceedling VSCode test adapter.
> 
> - **Server/HTTP (Deno)**:
>   - New `row_007_mod.ts` providing `HttpStatus`, routing decorators (`Get/Post/...`), middleware execution, route matching, and response/error handling.
> - **VSCode Extension (templates)**:
>   - New `row_016_command.ts` with commands to create/open/sync/update/insert templates; supports git-based sync.
> - **TIDAL Patcher**:
>   - New `row_028_patch.ts` and `row_029_patch.ts` to extract/modify/repack `app.asar`, inject Discord RPC, add tray/help/download menus, enable dev menu, and manage TIDAL Media Downloader; includes npm detection/installation.
> - **Testing Adapter**:
>   - New `row_037_adapter.ts` implementing `CeedlingAdapter` (`vscode-test-adapter-api`): loads/runs/debugs tests, parses YAML/XML reports, watches files for autorun/reload, and integrates problem matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51c862991e205562ee895e41e88e349abfeed9cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->