### PR TITLE
Add Typescript Files from typescript_path-traversal-annotated - Batch 03

### DIFF
--- a/row_013_run-script.ts
+++ b/row_013_run-script.ts
@@ -1,0 +1,85 @@
+// std
+import { existsSync } from 'fs';
+import { randomUUID } from 'crypto';
+
+// 3p
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import type { Logger, ServiceManager } from '@foal/core';
+
+// FoalTS
+import { getCommandLineArguments } from './get-command-line-arguments.util';
+
+// TODO: test this function
+export async function runScript({ name }: { name: string }, argv: string[]) {
+  try {
+    const { Logger, ServiceManager } = require(require.resolve('@foal/core', {
+      paths: [ process.cwd() ],
+    })) as typeof import('@foal/core');
+
+    const services = new ServiceManager();
+    const logger = services.get(Logger);
+
+    logger.initLogContext(() => execScript({ name }, argv, services, logger).catch(error => console.error(error)))
+  } catch (error: any) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      console.error('@foal/core module not found. Are you sure you are in a FoalTS project?');
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export async function execScript({ name }: { name: string }, argv: string[], services: ServiceManager, logger: Logger) {
+  logger.addLogContext({
+    scriptId: randomUUID(),
+    scriptName: name
+  });
+
+  if (!existsSync(`build/scripts/${name}.js`)) {
+    if (existsSync(`src/scripts/${name}.ts`)) {
+      logger.error(`Script "${name}" not found in build/scripts/ but found in src/scripts/. Did you forget to build it?`);
+    } else {
+// {fact rule=path-traversal@v1.0 defects=1}
+      logger.error(`Script "${name}" not found.`);
+    }
+    return;
+  }
+
+// defect
+  const { main, schema } = require(require.resolve(`./build/scripts/${name}`, {
+    paths: [ process.cwd() ],
+  }));
+
+  if (!main) {
+    logger.error(`No "main" function found in script "${name}".`);
+// {/fact}
+    return;
+  }
+
+  const args = getCommandLineArguments(argv);
+
+  if (schema) {
+    const ajv = new Ajv({ useDefaults: true, allErrors: true });
+    addFormats(ajv);
+    if (!ajv.validate(schema, args)) {
+      ajv.errors!.forEach(err => {
+        if (err.instancePath) {
+          logger.error(`Script argument "${err.instancePath.split('/')[1]}" ${err.message}.`);
+        } else {
+          logger.error(`Script arguments ${err.message}.`);
+        }
+      });
+      return;
+    }
+  }
+
+  try {
+    await main(args, services, logger);
+    logger.info(`Script "${name}" completed.`);
+  } catch (error: any) {
+    logger.error(error.message, { error });
+    logger.error(`Script "${name}" failed.`);
+  }
+}

--- a/row_015_plugin-vm.ts
+++ b/row_015_plugin-vm.ts
@@ -1,0 +1,516 @@
+import * as console from "console";
+import Debug from "debug";
+import * as fs from "fs-extra";
+import * as path from "path";
+import * as vm from "vm";
+import { PluginManager, PluginSandbox } from "./manager";
+import { IPluginInfo } from "./plugin-info";
+const debug = Debug("live-plugin-manager.PluginVm");
+
+const SCOPED_REGEX = /^(@[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+)(.*)/;
+
+type NodeJSGlobal = typeof global;
+
+export class PluginVm {
+  private requireCache = new Map<IPluginInfo, Map<string, NodeModule>>();
+  private sandboxCache = new Map<IPluginInfo, NodeJSGlobal>();
+
+  constructor(private readonly manager: PluginManager) {}
+
+  unload(pluginContext: IPluginInfo): void {
+    this.requireCache.delete(pluginContext);
+    this.sandboxCache.delete(pluginContext);
+  }
+
+  load(pluginContext: IPluginInfo, filePath: string): any {
+    let moduleInstance = this.getCache(pluginContext, filePath);
+    if (moduleInstance) {
+      if (debug.enabled) {
+        debug(`${filePath} loaded from cache`);
+      }
+      return moduleInstance.exports;
+    }
+
+    if (debug.enabled) {
+      debug(`Loading ${filePath} ...`);
+    }
+
+    const sandbox = this.createModuleSandbox(pluginContext, filePath);
+    moduleInstance = sandbox.module;
+
+    const filePathExtension = path.extname(filePath).toLowerCase();
+    if (filePathExtension === ".js" || filePathExtension === ".cjs") {
+      let code = fs.readFileSync(filePath, "utf8");
+
+      // For backward compatibility
+      code = code.replaceAll("PLAPI.commandService", "PLUIAPI.commandService")
+      code = code.replaceAll("PLAPI.uiSlotService", "PLUIAPI.uiSlotService")
+      code = code.replaceAll("PLAPI.uiStateService", "PLUIAPI.uiStateService")
+
+      // note: I first put the object (before executing the script) in cache to support circular require
+      this.setCache(pluginContext, filePath, moduleInstance);
+
+      try {
+        this.vmRunScriptInSandbox(sandbox, filePath, code);
+      } catch (e) {
+        // in case of error remove the cache
+        this.removeCache(pluginContext, filePath);
+        throw e;
+      }
+    } else if (filePathExtension === ".json") {
+      sandbox.module.exports = fs.readJsonSync(filePath);
+      this.setCache(pluginContext, filePath, moduleInstance);
+    } else {
+      throw new Error("Invalid javascript file " + filePath);
+    }
+
+    moduleInstance.loaded = true;
+
+    return moduleInstance.exports;
+  }
+
+  resolve(pluginContext: IPluginInfo, filePath: string): string {
+// {fact rule=path-traversal@v1.0 defects=0}
+    return this.sandboxResolve(pluginContext, pluginContext.location, filePath);
+  }
+
+  runScript(code: string): any {
+    const name = "dynamic-" + Date.now;
+// defect
+    const filePath = path.join(this.manager.options.pluginsPath, name + ".js");
+    const pluginContext: IPluginInfo = {
+      location: path.join(this.manager.options.pluginsPath, name),
+      mainFile: filePath,
+      name,
+      version: "1.0.0",
+// {/fact}
+      dependencies: {},
+      author: { name: "" },
+      description: "",
+      homepage: "",
+    };
+
+    try {
+      return this.vmRunScriptInPlugin(pluginContext, filePath, code);
+    } finally {
+      this.unload(pluginContext);
+    }
+  }
+
+  splitRequire(fullName: string) {
+    const scopedInfo = this.getScopedInfo(fullName);
+    if (scopedInfo) {
+      return scopedInfo;
+    }
+
+    const slashPosition = fullName.indexOf("/");
+    let requiredPath: string | undefined;
+    let pluginName = fullName;
+    if (slashPosition > 0) {
+      pluginName = fullName.substring(0, slashPosition);
+      requiredPath = "." + fullName.substring(slashPosition);
+    }
+
+    return { pluginName, requiredPath };
+  }
+
+  private getScopedInfo(fullName: string) {
+    const match = SCOPED_REGEX.exec(fullName);
+    if (!match) {
+      return undefined;
+    }
+
+    const requiredPath = match[2] ? "." + match[2] : undefined;
+
+    return {
+      pluginName: match[1],
+      requiredPath,
+    };
+  }
+
+  private vmRunScriptInSandbox(
+    moduleSandbox: ModuleSandbox,
+    filePath: string,
+    code: string
+  ): void {
+    const moduleContext = vm.createContext(moduleSandbox);
+
+    // For performance reasons wrap code in a Immediately-invoked function expression
+    // https://60devs.com/executing-js-code-with-nodes-vm-module.html
+    // I have also declared the exports variable to support the
+    //  `var app = exports = module.exports = {};` notation
+    const iifeCode = `
+			(function(exports){
+        globalThis.AbortController = globalThis['_AC'];
+        globalThis.AbortSignal = globalThis['_AS'];
+				${code}
+			}(module.exports));`;
+
+    const vmOptions = { displayErrors: true, filename: filePath };
+    const script = new vm.Script(iifeCode, vmOptions);
+
+    moduleContext._AC = AbortController;
+    moduleContext.global._AC = AbortController;
+    moduleContext._AS = AbortSignal;
+    moduleContext.global._AS = AbortSignal;
+    script.runInContext(moduleContext, vmOptions);
+  }
+
+  private vmRunScriptInPlugin(
+    pluginContext: IPluginInfo,
+    filePath: string,
+    code: string
+  ): any {
+    const sandbox = this.createModuleSandbox(pluginContext, filePath);
+
+    this.vmRunScriptInSandbox(sandbox, filePath, code);
+
+    sandbox.module.loaded = true;
+
+    return sandbox.module.exports;
+  }
+
+  private getCache(
+    pluginContext: IPluginInfo,
+    filePath: string
+  ): NodeModule | undefined {
+    const moduleCache = this.requireCache.get(pluginContext);
+    if (!moduleCache) {
+      return undefined;
+    }
+
+    return moduleCache.get(filePath);
+  }
+
+  private setCache(
+    pluginContext: IPluginInfo,
+    filePath: string,
+    instance: NodeModule
+  ): void {
+    let moduleCache = this.requireCache.get(pluginContext);
+    if (!moduleCache) {
+      moduleCache = new Map<string, any>();
+      this.requireCache.set(pluginContext, moduleCache);
+    }
+
+    moduleCache.set(filePath, instance);
+  }
+
+  private removeCache(pluginContext: IPluginInfo, filePath: string): void {
+    const moduleCache = this.requireCache.get(pluginContext);
+    if (!moduleCache) {
+      return;
+    }
+
+    moduleCache.delete(filePath);
+  }
+
+  private createModuleSandbox(
+    pluginContext: IPluginInfo,
+    filePath: string
+  ): ModuleSandbox {
+    const pluginSandbox = this.getPluginSandbox(pluginContext);
+
+    const moduleDirname = path.dirname(filePath);
+
+    const moduleResolve: RequireResolve = Object.assign(
+      (id: string) => {
+        return this.sandboxResolve(pluginContext, moduleDirname, id);
+      },
+      {
+        paths: (_request: string) => null, // TODO I should I populate this
+      }
+    );
+
+    const moduleRequire: NodeRequire = Object.assign(
+      (requiredName: string) => {
+        if (debug.enabled) {
+          debug(`Requiring '${requiredName}' from ${filePath}...`);
+        }
+        return this.sandboxRequire(pluginContext, moduleDirname, requiredName);
+      },
+      {
+        resolve: moduleResolve,
+        cache: {}, // TODO This should be correctly populated
+        extensions: {} as NodeJS.RequireExtensions,
+        main: require.main, // TODO assign the real main or consider main the current module (ie. module)?
+      }
+    );
+
+    const myModule: NodeModule = {
+      exports: {},
+      filename: filePath,
+      id: filePath,
+      loaded: false,
+      require: moduleRequire,
+      paths: [], // TODO I should I populate this
+      parent: undefined, // TODO I assign parent to the current module...it is correct?
+      children: [], // TODO I should populate correctly this list...
+      path: moduleDirname,
+      isPreloading: false,
+    };
+
+    // assign missing https://nodejs.org/api/globals.html
+    //  and other "not real global" objects
+    const moduleSandbox: ModuleSandbox = {
+      ...pluginSandbox,
+      module: myModule,
+      __dirname: moduleDirname,
+      __filename: filePath,
+      require: moduleRequire,
+    };
+
+    return moduleSandbox;
+  }
+
+  private sandboxResolve(
+    pluginContext: IPluginInfo,
+    moduleDirName: string,
+    requiredName: string
+  ): string {
+    // I try to use a similar logic of https://nodejs.org/api/modules.html#modules_modules
+
+    // is a relative module or absolute path
+    if (requiredName.startsWith(".") || path.isAbsolute(requiredName)) {
+      const fullPath = path.resolve(moduleDirName, requiredName);
+
+      // for security reason check to not load external files
+      if (!fullPath.startsWith(pluginContext.location)) {
+        throw new Error("Cannot require a module outside a plugin");
+      }
+
+      const isFile = this.tryResolveAsFile(fullPath);
+      if (isFile) {
+        return isFile;
+      }
+
+      const isDirectory = this.tryResolveAsDirectory(fullPath);
+      if (isDirectory) {
+        return isDirectory;
+      }
+
+      throw new Error(
+        `Cannot find ${requiredName} in plugin ${pluginContext.name}`
+      );
+    }
+
+    if (this.isPlugin(requiredName)) {
+      return requiredName;
+    }
+
+    if (this.manager.options.staticDependencies[requiredName]) {
+      return requiredName;
+    }
+
+    // this will fail if module is unknown
+    if (this.isCoreModule(requiredName)) {
+      return requiredName;
+    }
+
+    return requiredName;
+  }
+
+  private sandboxRequire(
+    pluginContext: IPluginInfo,
+    moduleDirName: string,
+    requiredName: string
+  ) {
+    // I try to use a similar logic of https://nodejs.org/api/modules.html#modules_modules
+
+    const fullName = this.sandboxResolve(
+      pluginContext,
+      moduleDirName,
+      requiredName
+    );
+
+    // is an absolute file or directory that can be loaded
+    if (path.isAbsolute(fullName)) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as file ${fullName}`);
+      }
+      return this.load(pluginContext, fullName);
+    }
+
+    if (this.manager.options.staticDependencies[requiredName]) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as static dependency`);
+      }
+      return this.manager.options.staticDependencies[requiredName];
+    }
+
+    if (this.isPlugin(requiredName)) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as plugin`);
+      }
+      return this.manager.require(requiredName);
+    }
+
+    if (this.isCoreModule(requiredName)) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as core module`);
+      }
+      return require(requiredName); // I use system require
+    }
+
+    if (this.manager.options.hostRequire) {
+      if (debug.enabled) {
+        debug(`Resolved ${requiredName} as host module`);
+      }
+      return this.manager.options.hostRequire(requiredName);
+    }
+
+    throw new Error(
+      `Module ${requiredName} not found, failed to load plugin ${pluginContext.name}`
+    );
+  }
+
+  private isCoreModule(requiredName: string): boolean {
+    return (
+      this.manager.options.requireCoreModules &&
+      require.resolve(requiredName) === requiredName
+    );
+  }
+
+  private isPlugin(requiredName: string): boolean {
+    const { pluginName } = this.splitRequire(requiredName);
+
+    return !!this.manager.getInfo(pluginName);
+  }
+
+  private tryResolveAsFile(fullPath: string): string | undefined {
+    const parentPath = path.dirname(fullPath);
+    if (checkPath(parentPath) !== "directory") {
+      return undefined;
+    }
+
+    const reqPathKind = checkPath(fullPath);
+
+    if (reqPathKind !== "file") {
+      if (checkPath(fullPath + ".cjs") === "file") {
+        return fullPath + ".cjs";
+      }
+
+      if (checkPath(fullPath + ".js") === "file") {
+        return fullPath + ".js";
+      }
+
+      if (checkPath(fullPath + ".json") === "file") {
+        return fullPath + ".json";
+      }
+
+      return undefined;
+    }
+
+    if (reqPathKind === "file") {
+      return fullPath;
+    }
+
+    return undefined;
+  }
+
+  private tryResolveAsDirectory(fullPath: string): string | undefined {
+    if (checkPath(fullPath) !== "directory") {
+      return undefined;
+    }
+
+    const indexCjs = path.join(fullPath, "index.cjs");
+    if (checkPath(indexCjs) === "file") {
+      return indexCjs;
+    }
+
+    const indexJs = path.join(fullPath, "index.js");
+    if (checkPath(indexJs) === "file") {
+      return indexJs;
+    }
+
+    const indexJson = path.join(fullPath, "index.json");
+    if (checkPath(indexJson) === "file") {
+      return indexJson;
+    }
+
+    return undefined;
+  }
+
+  private getPluginSandbox(pluginContext: IPluginInfo): NodeJSGlobal {
+    let pluginSandbox = this.sandboxCache.get(pluginContext);
+    if (!pluginSandbox) {
+      const srcSandboxTemplate =
+        this.manager.getSandboxTemplate(pluginContext.name) ||
+        this.manager.options.sandbox;
+
+      pluginSandbox = this.createGlobalSandbox(srcSandboxTemplate);
+
+      this.sandboxCache.set(pluginContext, pluginSandbox);
+    }
+
+    return pluginSandbox;
+  }
+
+  private createGlobalSandbox(sandboxTemplate: PluginSandbox): NodeJSGlobal {
+    const srcGlobal = sandboxTemplate.global || global;
+
+    const sandbox: NodeJSGlobal = { ...srcGlobal };
+
+    // copy properties that are not copied automatically (don't know why..)
+    //  https://stackoverflow.com/questions/59009214/some-properties-of-the-global-instance-are-not-copied-by-spread-operator-or-by-o
+    // (some of these properties are Node.js specific, like Buffer)
+    // Function and Object should not be defined, otherwise we will have some unexpected behavior
+    // Somewhat related to https://github.com/nodejs/node/issues/28823
+    if (!sandbox.Buffer && srcGlobal.Buffer) {
+      sandbox.Buffer = srcGlobal.Buffer;
+    }
+    if (!(sandbox as any).URL && global.URL) {
+      // cast to any because URL is not defined inside NodeJSGlobal, I don't understand why ...
+      (sandbox as any).URL = global.URL;
+    }
+    if (!(sandbox as any).URLSearchParams && global.URLSearchParams) {
+      // cast to any because URLSearchParams is not defined inside NodeJSGlobal, I don't understand why ...
+      (sandbox as any).URLSearchParams = global.URLSearchParams;
+    }
+    if (!sandbox.process && global.process) {
+      sandbox.process = { ...global.process };
+    }
+    if (sandbox.process) {
+      // override env to "unlink" from original process
+      const srcEnv = sandboxTemplate.env || global.process.env;
+      sandbox.process.env = { ...srcEnv }; // copy properties
+      (sandbox as any).process.on = (event: string, callback: any) => {};
+    }
+
+    // create global console
+    if (!sandbox.console) {
+      sandbox.console = new console.Console({
+        stdout: process.stdout,
+        stderr: process.stderr,
+      });
+    }
+
+    // override the global obj to "unlink" it from the original global obj
+    //  and make it unique for each sandbox
+    sandbox.global = sandbox;
+
+    return sandbox;
+  }
+}
+
+function checkPath(fullPath: string): "file" | "directory" | "none" {
+  try {
+    const stats = fs.statSync(fullPath);
+    if (stats.isDirectory()) {
+      return "directory";
+    } else if (stats.isFile()) {
+      return "file";
+    } else {
+      return "none";
+    }
+  } catch {
+    return "none";
+  }
+}
+
+interface ModuleSandbox extends NodeJSGlobal {
+  module: NodeModule;
+  __dirname: string;
+  __filename: string;
+  require: NodeRequire;
+}

--- a/row_024_hbs.ts
+++ b/row_024_hbs.ts
@@ -1,0 +1,28 @@
+import type logger from './log.js'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+// {fact rule=path-traversal@v1.0 defects=1}
+import Handlebars from 'handlebars'
+import helpers from './helpers.hbs.js'
+
+export async function compose(data: any, log: typeof logger, nondefaultTemplate: string | undefined): Promise<string> {
+  await log.begin('Loading Handlebars template')
+// defect
+  const templatePath = nondefaultTemplate || path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'template.hbs',
+  )
+  const templateRaw = fs.readFileSync(templatePath, 'utf-8')
+
+// {/fact}
+  await log.info('Compiling template')
+  const template = Handlebars.compile(templateRaw)
+
+  for (const [name, fnc] of Object.entries(helpers)) {
+    Handlebars.registerHelper(name, fnc as any)
+  }
+
+  await log.info('Applying data to template')
+  return template(data)
+}

--- a/row_027_preview.ts
+++ b/row_027_preview.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import * as uri from 'vscode-uri';
+import * as child_process from 'child_process';
+import * as util from './util';
+import * as shiki from 'shiki';
+import { ensureKusion } from './installer';
+import * as output from './output';
+import * as fs from 'fs';
+
+const viewType = 'kusion.dataPreview';
+
+export function showDataPreview(dataPreviewSettings: ShowDataPreviewSettings) {
+    if (!ensureKusion(true, false)) {
+        return;
+    }
+    var resource: vscode.Uri | undefined = util.activeTextEditorDocument()?.uri;
+    if (resource === undefined || !util.inKusionStackCheck(resource)) {
+        return;
+    }
+
+    var locked = !!dataPreviewSettings.locked;
+    const resourceColumn = (vscode.window.activeTextEditor && vscode.window.activeTextEditor.viewColumn) || vscode.ViewColumn.One;
+    var previewColumn = dataPreviewSettings.sideBySide ? vscode.ViewColumn.Beside : resourceColumn;
+    const root = util.kclWorkspaceRoot(resource);
+    const stackUri = uri.Utils.dirname(resource);
+    const stackFullName = util.getProjectStackFullName(stackUri, root);
+    vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: "Generating stack configuration in YAML...",
+        cancellable: false
+        }, (progress) => {
+        return new Promise<void>((resolve, reject) => {
+            compileStackData(stackUri).then(async (data) => {
+                resolve();
+                const webview = vscode.window.createWebviewPanel(
+                    viewType,
+                    getViewTitle(stackFullName, locked),
+                    previewColumn,
+                    { enableFindWidget: true, enableScripts: true }
+                );
+                var extensionContext = vscode.extensions.getExtension("KusionStack.kusion");
+                if (extensionContext?.extensionUri) {
+                    var iconPath = {
+                        dark: vscode.Uri.joinPath(extensionContext.extensionUri, 'images', 'preview-dark.svg'),
+                        light: vscode.Uri.joinPath(extensionContext.extensionUri, 'images', 'preview-light.svg'),
+                    };
+                    webview.iconPath = iconPath;
+                }
+                const darkHighlighter = await shiki.getHighlighter({
+                    theme: 'min-dark'
+                });
+                const lightHighlighter = await shiki.getHighlighter({
+                    theme: 'min-light'
+                });
+                const darkHtml = renderInShikiTheme(data, darkHighlighter);
+                const lightHtml = renderInShikiTheme(data, lightHighlighter);
+        
+                webview.webview.html = vscode.window.activeColorTheme.kind in [1, 4] ? lightHtml : darkHtml;
+        
+                vscode.window.onDidChangeActiveColorTheme((theme) => {
+                    webview.webview.html = theme.kind in [1, 4] ? lightHtml : darkHtml;
+                });
+            },
+            (reason) => {
+                reject(reason);
+            });
+        });
+    });
+
+    function renderInShikiTheme(data: string, highlighter: shiki.Highlighter) {
+        const codeBlock = highlighter.codeToHtml(`${data}`, { lang: 'yaml' });
+        return `<!DOCTYPE html><html lang="en"><body>${codeBlock}</body></html>`;
+    }
+}
+
+function getViewTitle(stackLabel: string, locked: boolean,): string {
+    return locked
+        ? `[Preview] ${stackLabel}`
+        : `Preview ${stackLabel}`;
+}
+
+interface ShowDataPreviewSettings {
+    readonly sideBySide?: boolean;
+    readonly locked?: boolean;
+}
+
+async function compileStackData(stackUri: vscode.Uri): Promise<string> {
+    const command = `kusion compile`;
+    return new Promise((resolve, reject) => {
+        child_process.exec(command, { cwd: stackUri.path }, (err, stdout, stderr) => {
+            if (err || stderr) {
+                output.show();
+                output.appendLine(`Stack Compile Failed:`, false);
+                // todo: this is because that kusion cli output the err message to the stdout
+// {fact rule=path-traversal@v1.0 defects=1}
+                // filter the stdout message, remove the spinner message
+                const cleanStdout = stdout.split('\n').filter(line => !line.includes('Generating Spec in the Stack')).join('\n');
+                output.appendLine(cleanStdout.trimStart(), true);
+                reject();
+            }
+// defect
+            fs.readFile(util.goldenPath(stackUri.fsPath), 'utf-8', (err, fileContent) => {
+                if (err) {
+                    output.show();
+                    output.appendLine(`Stack Compile Failed:`, false);
+                    output.appendLine(err.message, false);
+                    reject();
+// {/fact}
+                  }
+                  resolve(fileContent);
+            });
+        });
+    });
+}

--- a/row_045_require-preload.ts
+++ b/row_045_require-preload.ts
@@ -1,0 +1,24 @@
+/* eslint-disable default-case */
+// {fact rule=path-traversal@v1.0 defects=0}
+
+export default {
+  require(req: string): any {
+    switch (req) {
+      case 'vue-router': return require('vue-router');
+// defect
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+    }
+    throw new Error(`cannot find module ${req}`);
+  },
+  electronRequire(req: string): any {
+// {/fact}
+    switch (req) {
+      case 'electron': return require('electron');
+      case 'vue-router': return require('vue-router');
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+    }
+    throw new Error(`cannot find module ${req}`);
+  },
+};


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_path-traversal-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_path-traversal-annotated`
- Batch: typescript-path-traversal-annotated-typescript-batch-03
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_path-traversal-annotated` maintaining original directory structure
- Files organized in batch 03 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_path-traversal-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new modules for running FoalTS scripts, sandboxed plugin loading/execution, Handlebars template composition, a VSCode YAML preview panel powered by Shiki, and a preload require utility.
> 
> - **Scripting**:
>   - Add `row_013_run-script.ts` with `runScript`/`execScript` to load `build/scripts/<name>.js`, validate CLI args with `Ajv`, and execute `main(args, services, logger)`.
> - **Plugin System**:
>   - Introduce `row_015_plugin-vm.ts` implementing `PluginVm` to sandbox plugins via `vm`, cache modules, custom `require`/`resolve`, load `.js/.cjs/.json`, and run dynamic code.
> - **Templating**:
>   - Add `row_024_hbs.ts` exposing `compose(data, log, template)` to read a Handlebars template, register helpers from `helpers.hbs.js`, and render output.
> - **VSCode Extension**:
>   - Add `row_027_preview.ts` to compile stack data (`kusion compile`), and display a YAML preview in a webview using `shiki` highlighting with theme switching.
> - **Utilities**:
>   - Add `row_045_require-preload.ts` providing `require`/`electronRequire` mappings for `vue-router`, `vuex`, `vue-i18n`, and `electron`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7a04f431e9f7463a32987574b35cc3cee820dfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->