### PR TITLE
Add Typescript Files from typescript_path-traversal-annotated - Batch 04

### DIFF
--- a/row_001_release.ts
+++ b/row_001_release.ts
@@ -1,0 +1,150 @@
+/* eslint-disable  import/no-extraneous-dependencies,@typescript-eslint/camelcase, no-console */
+import inquirer from 'inquirer';
+import fs from 'fs';
+import path from 'path';
+import child_process from 'child_process';
+import util from 'util';
+import chalk from 'chalk';
+import semverInc from 'semver/functions/inc';
+import { ReleaseType } from 'semver';
+
+import pkg from '../package.json';
+
+const exec = util.promisify(child_process.exec);
+
+const run = async (command: string) => {
+  console.log(chalk.green(command));
+  await exec(command);
+};
+
+const currentVersion = pkg.version;
+
+const getNextVersions = (): { [key in ReleaseType]: string | null } => ({
+  major: semverInc(currentVersion, 'major'),
+  minor: semverInc(currentVersion, 'minor'),
+  patch: semverInc(currentVersion, 'patch'),
+  premajor: semverInc(currentVersion, 'premajor'),
+  preminor: semverInc(currentVersion, 'preminor'),
+  prepatch: semverInc(currentVersion, 'prepatch'),
+  prerelease: semverInc(currentVersion, 'prerelease'),
+});
+
+const timeLog = (logInfo: string, type: 'start' | 'end') => {
+  let info = '';
+  if (type === 'start') {
+    info = `=> 开始任务：${logInfo}`;
+  } else {
+    info = `✨ 结束任务：${logInfo}`;
+  }
+  const nowDate = new Date();
+  console.log(
+    `[${nowDate.toLocaleString()}.${nowDate.getMilliseconds().toString().padStart(3, '0')}] ${info}
+    `,
+  );
+};
+
+/**
+ * 询问获取下一次版本号
+ */
+async function prompt(): Promise<string> {
+  const nextVersions = getNextVersions();
+  const { nextVersion } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'nextVersion',
+      message: `请选择将要发布的版本 (当前版本 ${currentVersion})`,
+      choices: (Object.keys(nextVersions) as Array<ReleaseType>).map((level) => ({
+        name: `${level} => ${nextVersions[level]}`,
+        value: nextVersions[level],
+      })),
+    },
+  ]);
+  return nextVersion;
+}
+
+/**
+ * 更新版本号
+// {fact rule=path-traversal@v1.0 defects=1}
+ * @param nextVersion 新版本号
+ */
+async function updateVersion(nextVersion: string) {
+  pkg.version = nextVersion;
+  timeLog('修改package.json版本号', 'start');
+// defect
+  await fs.writeFileSync(path.resolve(__dirname, './../package.json'), JSON.stringify(pkg));
+  await run('npx prettier package.json --write');
+  timeLog('修改package.json版本号', 'end');
+}
+
+/**
+// {/fact}
+ * 生成CHANGELOG
+ */
+async function generateChangelog() {
+  timeLog('生成CHANGELOG.md', 'start');
+  await run(' npx conventional-changelog -p angular -i CHANGELOG.md -s -r 0');
+  timeLog('生成CHANGELOG.md', 'end');
+}
+
+/**
+ * 将代码提交至git
+ */
+async function push(nextVersion: string) {
+  timeLog('推送代码至git仓库', 'start');
+  await run('git add package.json CHANGELOG.md');
+  await run(`git commit -m "v${nextVersion}" -n`);
+  await run('git push');
+  timeLog('推送代码至git仓库', 'end');
+}
+
+/**
+ * 组件库打包
+ */
+async function build() {
+  timeLog('组件库打包', 'start');
+  await run('npm run build');
+  timeLog('组件库打包', 'end');
+}
+
+/**
+ * 发布至npm
+ */
+async function publish() {
+  timeLog('发布组件库', 'start');
+  await run('npm publish');
+  timeLog('发布组件库', 'end');
+}
+
+/**
+ * 打tag提交至git
+ */
+async function tag(nextVersion: string) {
+  timeLog('打tag并推送至git', 'start');
+  await run(`git tag v${nextVersion}`);
+  await run(`git push origin tag v${nextVersion}`);
+  timeLog('打tag并推送至git', 'end');
+}
+
+async function main() {
+  try {
+    const nextVersion = await prompt();
+    const startTime = Date.now();
+    // =================== 更新版本号 ===================
+    await updateVersion(nextVersion);
+    // =================== 更新changelog ===================
+    await generateChangelog();
+    // =================== 代码推送git仓库 ===================
+    await push(nextVersion);
+    // =================== 组件库打包 ===================
+    await build();
+    // =================== 发布至npm ===================
+    await publish();
+    // =================== 打tag并推送至git ===================
+    await tag(nextVersion);
+    console.log(`✨ 发布流程结束 共耗时${((Date.now() - startTime) / 1000).toFixed(3)}s`);
+  } catch (error) {
+    console.log('💣 发布失败，失败原因：', error);
+  }
+}
+
+main();

--- a/row_005_suppressions.ts
+++ b/row_005_suppressions.ts
@@ -1,0 +1,229 @@
+import { Stats } from "fs";
+import { access, constants, lstat, readFile } from "fs/promises";
+import { minimatch } from "minimatch";
+import { createRequire } from "module";
+import { dirname, join, resolve, sep } from "path";
+import { sep as posixSep } from "path/posix";
+import vm from "vm";
+import { parse as yamlParse } from "yaml";
+import * as z from "zod";
+
+export interface Suppression {
+  tool: string;
+  // String of JavaScript CJS code, executed in a prepared context, that determines if a suppression should be included
+  if?: string;
+  // Output only exposes "paths".  For input, if "path" is defined, it is inserted at the start of "paths".
+  paths: string[];
+  rules?: string[];
+  subRules?: string[];
+  reason: string;
+}
+
+const suppressionSchema = z.array(
+  z
+    .object({
+      tool: z.string(),
+      if: z.string().optional(),
+      // For now, input allows "path" alongside "paths".  Lather, may deprecate "path".
+      path: z.string().optional(),
+      paths: z.array(z.string()).optional(),
+      rules: z.array(z.string()).optional(),
+      "sub-rules": z.array(z.string()).optional(),
+      reason: z.string(),
+    })
+    .refine((data) => data.path || data.paths?.[0], {
+      message: "Either 'path' or 'paths' must be present",
+      path: ["path", "paths"],
+    })
+    .transform((s) => {
+      let paths: string[] = Array.from(s.paths || []);
+      if (s.path) {
+        // if "path" is defined, it is inserted at the start of "paths".
+        paths.unshift(s.path);
+      }
+      return {
+        tool: s.tool,
+        if: s.if,
+        paths: paths,
+        rules: s.rules,
+        subRules: s["sub-rules"],
+        reason: s.reason,
+      } as Suppression;
+    }),
+);
+
+/**
+ * Returns the suppressions for a tool applicable to a path.  Walks up the directory tree to find all files named
+ * "suppressions.yaml", parses and validates the contents, and returns the suppressions matching the tool and path.
+ * Suppressions are ordered by file (closest to path is first), then within the file (closest to top is first).
+ *
+ * @param tool Name of tool. Matched against property "tool" in suppressions.yaml.
+ * @param path Path to file or directory under analysis.
+ * @returns Array of suppressions matching tool and path (may be empty).
+ *
+ * @example
+ * ```
+ * // Prints
+ * // '[{
+ * //   "tool":"TypeSpecRequirement",
+ * //   "paths":["data-plane/foo/stable/2024-01-01/*.json"],
+ * //   "reason":"foo"
+ * //  }]':
+ * console.log(JSON.stringify(getSuppressions(
+ *   "TypeSpecRequirement",
+ *   "specification/foo/data-plane/Foo/stable/2024-01-01/foo.json"))
+ * );
+ * ```
+ */
+export async function getSuppressions(
+  tool: string,
+  path: string,
+  context: Record<string, any> = {},
+): Promise<Suppression[]> {
+  path = resolve(path);
+
+  // If path doesn't exist, throw instead of returning "[]" to prevent confusion
+  await access(path, constants.R_OK);
+
+  let suppressionsFiles: string[] = await findSuppressionsFiles(path);
+  let suppressions: Suppression[] = [];
+
+  for (let suppressionsFile of suppressionsFiles) {
+    suppressions = suppressions.concat(
+      getSuppressionsFromYaml(
+        tool,
+        path,
+        suppressionsFile,
+        await readFile(suppressionsFile, { encoding: "utf8" }),
+        context,
+      ),
+    );
+  }
+
+  return suppressions;
+}
+
+/**
+ * Returns the suppressions for a tool applicable to a path, given the path and content of the suppressions.yaml.
+ * Extracted for unit testing.
+ *
+ * @internal
+ *
+ * @param tool Name of tool. Matched against property "tool" in suppressions.yaml.
+ * @param path Path to file under analysis.
+ * @param suppressionsFile Path to suppressions.yaml file.
+ * @param suppressionsYaml Content of suppressions.yaml file.
+ * @returns Array of suppressions matching tool and path (may be empty).
+ * @example
+ * ```
+ * // Prints
+ * // '[{
+ * //    "tool":"TypeSpecRequirement",
+ * //    "path":"data-plane/foo/stable/2024-01-01/*.json",
+ * //    "reason":"foo"
+ * // }]':
+ * console.log(JSON.stringify(_getSuppressionsFromYaml(
+ *  "TypeSpecRequirement",
+ *  "specification/foo/data-plane/Foo/stable/2024-01-01/foo.json",
+ *  "specification/foo/suppressions.yaml",
+ *  '- tool: TypeSpecRequirement\n paths: ["data-plane/foo/stable/2024-01-01/*.json"]\n reason: foo'
+ * )));
+ * ```
+ */
+export function getSuppressionsFromYaml(
+  tool: string,
+  path: string,
+  suppressionsFile: string,
+  suppressionsYaml: string,
+  context: Record<string, any> = {},
+): Suppression[] {
+  path = resolve(path);
+  suppressionsFile = resolve(suppressionsFile);
+
+  // Treat empty yaml as empty array
+  const parsedYaml: any = yamlParse(suppressionsYaml) ?? [];
+
+  let suppressions: Suppression[];
+  try {
+    // Throws if parsedYaml doesn't match schema
+    suppressions = suppressionSchema.parse(parsedYaml);
+  } catch (err) {
+    let finalErr = err;
+    if (err instanceof z.ZodError) {
+      finalErr = new Error(z.prettifyError(err), { cause: err });
+    }
+    throw finalErr;
+  }
+
+  // Make "require" available inside sandbox for CJS imports
+  const sandbox = { ...context, require: createRequire(import.meta.url) };
+
+  return (
+    suppressions
+      // Tool name
+      .filter((s) => s.tool === tool)
+      // Path
+      .filter((s) => {
+        // Minimatch only allows forward-slashes in patterns and input
+        const pathPosix: string = path.split(sep).join(posixSep);
+
+        return s.paths.some((suppressionPath) => {
+          const pattern: string = join(dirname(suppressionsFile), suppressionPath)
+            .split(sep)
+            .join(posixSep);
+          return minimatch(pathPosix, pattern);
+        });
+      })
+      // If
+      .filter((s) => s.if === undefined || vm.runInNewContext(s.if, sandbox))
+  );
+}
+
+/**
+ * Returns absolute paths to all suppressions.yaml files applying to input (or "undefined" if none found).
+ * Walks up directory tree, returning all files matching "suppressions.yaml", in order (may be empty);
+ *
+ * @param path Path to file under analysis.
+ *
+ * @example
+ * ```
+ * // Prints
+ * //   '/home/user/specs/specification/foo/suppressions.yaml'
+ * //   '/home/user/specs/specification/suppressions.yaml
+ * console.log(findSuppressionsYaml(
+ *   "specification/foo/data-plane/Foo/stable/2024-01-01/foo.json"
+ * ));
+ * ```
+ */
+async function findSuppressionsFiles(path: string): Promise<string[]> {
+  const suppressionsFiles: string[] = [];
+
+  path = resolve(path);
+// {fact rule=path-traversal@v1.0 defects=1}
+
+  const stats: Stats = await lstat(path);
+  let currentDirectory: string = stats.isDirectory() ? path : dirname(path);
+
+  while (true) {
+// defect
+    const suppressionsFile: string = join(currentDirectory, "suppressions.yaml");
+    try {
+      // Throws if file cannot be read
+      await access(suppressionsFile, constants.R_OK);
+      suppressionsFiles.push(suppressionsFile);
+    } catch {
+// {/fact}
+      // File does not exist (or cannot be read), so skip this directory and check the parent
+    }
+
+    const parentDirectory: string = dirname(currentDirectory);
+    if (parentDirectory !== currentDirectory) {
+      currentDirectory = parentDirectory;
+    } else {
+      // Reached fs root
+      break;
+    }
+  }
+
+  return suppressionsFiles;
+}

--- a/row_022_service.ts
+++ b/row_022_service.ts
@@ -1,0 +1,174 @@
+
+
+import {ServiceService} from "@geoplatform/client";
+import ServiceProxy from "./base";
+
+
+const Routes = [
+    {
+        key: 'search',
+        method: 'get',
+        path: 'services',
+        auth: false,
+        onExecute: function(svc: ServiceService, req : any) {
+            return svc.search(req.query);
+        }
+    },
+    {
+        key: 'get',
+        method: 'get',
+        path: 'services/:id',
+        auth: false,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.get(req.params.id);
+        }
+    },
+    {
+        key: 'create',
+        method: 'post',
+        path: 'services',
+        auth: true,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.save(req.body);
+        }
+    },
+    {
+        key: 'update',
+        method: 'put',
+        path: 'services/:id',
+        auth: true,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.save(req.body);
+        }
+    },
+    {
+        key: 'delete',
+        method: 'delete',
+        path: 'services/:id',
+        auth: true,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.remove(req.params.id);
+        },
+        onResponse: function(
+            // @ts-ignore
+            result : any,
+            res : any) {
+            res.status(204).end();
+        }
+    },
+    {
+        key: 'patch',
+        method: 'patch',
+        path: 'services/:id',
+        auth: true,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.patch(req.params.id, req.body);
+        }
+    },
+    {
+        key: 'export',
+        method: 'get',
+        path: 'services/:id/export',
+        auth: false,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.export(req.params.id, req.query.format);
+        },
+        onResponse: function(result : any, res : any) {
+            let mimeType = result.headers['content-type'];
+            let disposition = result.headers['content-disposition'];
+            res.set("Content-Type", mimeType);
+            res.setHeader('Content-disposition', disposition);
+            res.send(result.body);
+        }
+    },
+    {
+        key: 'types',
+        method: 'get',
+        path: 'serviceTypes',
+        auth: false,
+        onExecute: function(svc : ServiceService) {
+            return svc.types();
+        }
+    },
+    {
+        key: 'import',
+        method: 'post',
+        path: 'services/import',
+        auth: true,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.import(req.body);
+        }
+    },
+    {
+        key: 'about',
+        method: 'get',
+        path: 'services/:id/about',
+        auth: false,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.about(req.params.id);
+        }
+    },
+    {
+        key: 'harvest',
+        method: 'get',
+        path: 'services/:id/harvest',
+        auth: false,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.harvest(req.params.id);
+        }
+    },
+    {
+        key: 'test',
+        method: 'get',
+        path: 'services/:id/test',
+        auth: false,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.liveTest(req.params.id);
+        }
+    },
+    {
+        key: 'statistics',
+        method: 'get',
+        path: 'services/:id/statistics',
+        auth: false,
+        onExecute: function(svc : ServiceService, req : any ) {
+            return svc.statistics(req.params.id);
+        }
+    }
+];
+
+
+
+
+/**
+ *
+ */
+function ServiceServiceProxy( options ?: any ) {
+
+    if(typeof(options) === 'undefined') {
+// {fact rule=path-traversal@v1.0 defects=0}
+        options = {};
+    };
+
+    let router = options.router;
+    if(!options.router) {
+// defect
+        let express = require('express');
+        if(!express) {
+            throw new Error("ServiceServiceProxy() - Must provide" +
+                "'options.router' or include express as a dependency");
+        }
+        router = express.Router();
+// {/fact}
+    }
+
+    if(!router) throw new Error("ServiceServiceProxy() - " +
+        "Unable to create proxy route, missing router");
+
+    options.serviceClass = ServiceService;
+    ServiceProxy.bindRoutes(router, Routes, options);
+
+    return router;
+}
+
+export default ServiceServiceProxy;

--- a/row_030_index.ts
+++ b/row_030_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+// {fact rule=path-traversal@v1.0 defects=1}
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+// defect
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+            await generate(path.join(rootDir, 'protobuf'));
+// {/fact}
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+}
+
+
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+    if (await fs.existsAsync(egretPropertiesPath)) {
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}

--- a/row_031_index.ts
+++ b/row_031_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+// {fact rule=path-traversal@v1.0 defects=1}
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+// defect
+            await generate(path.join(rootDir, 'protobuf'));
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+// {/fact}
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+}
+
+
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+    if (await fs.existsAsync(egretPropertiesPath)) {
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_path-traversal-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_path-traversal-annotated`
- Batch: typescript-path-traversal-annotated-typescript-batch-04
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_path-traversal-annotated` maintaining original directory structure
- Files organized in batch 04 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_path-traversal-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds service API routes proxy, YAML-based suppressions resolver, a release automation script, and protobuf add/generate tooling.
> 
> - **Backend/Routes**:
>   - Add `row_022_service.ts` implementing `ServiceServiceProxy` with routes for `search/get/create/update/delete/patch/export/types/import/about/harvest/test/statistics` bound to `ServiceService`.
> - **Utilities**:
>   - Add `row_005_suppressions.ts` to load and validate `suppressions.yaml` (via `zod`), match by tool/path (via `minimatch`), and support conditional inclusion (`if` via `vm`).
> - **Build/Release**:
>   - Add `row_001_release.ts` CLI to bump `package.json` version (using `semver`), generate `CHANGELOG`, push/tag, build, and publish to npm.
> - **Tooling (Protobuf for Egret)**:
>   - Add `row_030_index.ts` and `row_031_index.ts` providing `add`/`generate` commands using `pbjs/pbts`, producing JS, minified JS, and `.d.ts` bundles under `protobuf/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9120b8930218702eed71630543426ffccf723aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->