### PR TITLE
Add Typescript Files from typescript_path-traversal-annotated - Batch 07

### DIFF
--- a/row_012_run-script.ts
+++ b/row_012_run-script.ts
@@ -1,0 +1,85 @@
+// std
+import { existsSync } from 'fs';
+import { randomUUID } from 'crypto';
+
+// 3p
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import type { Logger, ServiceManager } from '@foal/core';
+
+// FoalTS
+// {fact rule=path-traversal@v1.0 defects=0}
+import { getCommandLineArguments } from './get-command-line-arguments.util';
+
+// TODO: test this function
+export async function runScript({ name }: { name: string }, argv: string[]) {
+  try {
+// defect
+    const { Logger, ServiceManager } = require(require.resolve('@foal/core', {
+      paths: [ process.cwd() ],
+    })) as typeof import('@foal/core');
+
+    const services = new ServiceManager();
+    const logger = services.get(Logger);
+// {/fact}
+
+    logger.initLogContext(() => execScript({ name }, argv, services, logger).catch(error => console.error(error)))
+  } catch (error: any) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      console.error('@foal/core module not found. Are you sure you are in a FoalTS project?');
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export async function execScript({ name }: { name: string }, argv: string[], services: ServiceManager, logger: Logger) {
+  logger.addLogContext({
+    scriptId: randomUUID(),
+    scriptName: name
+  });
+
+  if (!existsSync(`build/scripts/${name}.js`)) {
+    if (existsSync(`src/scripts/${name}.ts`)) {
+      logger.error(`Script "${name}" not found in build/scripts/ but found in src/scripts/. Did you forget to build it?`);
+    } else {
+      logger.error(`Script "${name}" not found.`);
+    }
+    return;
+  }
+
+  const { main, schema } = require(require.resolve(`./build/scripts/${name}`, {
+    paths: [ process.cwd() ],
+  }));
+
+  if (!main) {
+    logger.error(`No "main" function found in script "${name}".`);
+    return;
+  }
+
+  const args = getCommandLineArguments(argv);
+
+  if (schema) {
+    const ajv = new Ajv({ useDefaults: true, allErrors: true });
+    addFormats(ajv);
+    if (!ajv.validate(schema, args)) {
+      ajv.errors!.forEach(err => {
+        if (err.instancePath) {
+          logger.error(`Script argument "${err.instancePath.split('/')[1]}" ${err.message}.`);
+        } else {
+          logger.error(`Script arguments ${err.message}.`);
+        }
+      });
+      return;
+    }
+  }
+
+  try {
+    await main(args, services, logger);
+    logger.info(`Script "${name}" completed.`);
+  } catch (error: any) {
+    logger.error(error.message, { error });
+    logger.error(`Script "${name}" failed.`);
+  }
+}

--- a/row_034_index.ts
+++ b/row_034_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+            await generate(path.join(rootDir, 'protobuf'));
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+// {fact rule=path-traversal@v1.0 defects=1}
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+// defect
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+// {/fact}
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+}
+
+
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+    if (await fs.existsAsync(egretPropertiesPath)) {
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}

--- a/row_035_index.ts
+++ b/row_035_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+            await generate(path.join(rootDir, 'protobuf'));
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+// {fact rule=path-traversal@v1.0 defects=1}
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+// defect
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+// {/fact}
+}
+
+
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+    if (await fs.existsAsync(egretPropertiesPath)) {
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}

--- a/row_042_index.ts
+++ b/row_042_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+            await generate(path.join(rootDir, 'protobuf'));
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+}
+
+
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+// {fact rule=path-traversal@v1.0 defects=1}
+    if (await fs.existsAsync(egretPropertiesPath)) {
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+// defect
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+// {/fact}
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}

--- a/row_043_index.ts
+++ b/row_043_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+            await generate(path.join(rootDir, 'protobuf'));
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+}
+
+
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+    if (await fs.existsAsync(egretPropertiesPath)) {
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+// {fact rule=path-traversal@v1.0 defects=1}
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+// defect
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+// {/fact}
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_path-traversal-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_path-traversal-annotated`
- Batch: typescript-path-traversal-annotated-typescript-batch-07
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_path-traversal-annotated` maintaining original directory structure
- Files organized in batch 07 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_path-traversal-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a FoalTS-based script runner and multiple protobuf generation CLI utilities for Egret projects, including argument parsing/validation, codegen, minification, and project config updates.
> 
> - **Utilities**
>   - `row_012_run-script.ts`: Introduces `runScript` and `execScript` to load FoalTS services (`ServiceManager`, `Logger`), parse argv via `getCommandLineArguments`, optionally validate against `ajv` schemas, and execute built scripts from `build/scripts/*`.
> - **Protobuf CLI (Egret)**
>   - `row_034_index.ts`, `row_035_index.ts`, `row_042_index.ts`, `row_043_index.ts`: Add CLI to `add` protobuf library to an Egret project and `generate` bundles from `.proto` files.
>     - Reads `pbconfig.json`, validates `.proto` files, runs `pbjs`/`pbts`, writes JS, `.min.js`, and `.d.ts` outputs, and updates `egretProperties.json` and `tsconfig.json` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97a3c070978c469cb3e45d49b8778d0442e7b3ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->