### PR TITLE
Add Typescript Files from typescript_path-traversal-annotated - Batch 09

### DIFF
--- a/row_025_hbs.ts
+++ b/row_025_hbs.ts
@@ -1,0 +1,28 @@
+import type logger from './log.js'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Handlebars from 'handlebars'
+import helpers from './helpers.hbs.js'
+
+export async function compose(data: any, log: typeof logger, nondefaultTemplate: string | undefined): Promise<string> {
+// {fact rule=path-traversal@v1.0 defects=1}
+  await log.begin('Loading Handlebars template')
+  const templatePath = nondefaultTemplate || path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'template.hbs',
+  )
+// defect
+  const templateRaw = fs.readFileSync(templatePath, 'utf-8')
+
+  await log.info('Compiling template')
+  const template = Handlebars.compile(templateRaw)
+
+  for (const [name, fnc] of Object.entries(helpers)) {
+// {/fact}
+    Handlebars.registerHelper(name, fnc as any)
+  }
+
+  await log.info('Applying data to template')
+  return template(data)
+}

--- a/row_038_index.ts
+++ b/row_038_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+            await generate(path.join(rootDir, 'protobuf'));
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+}
+
+// {fact rule=path-traversal@v1.0 defects=1}
+
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+// defect
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+    if (await fs.existsAsync(egretPropertiesPath)) {
+// {/fact}
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}

--- a/row_039_index.ts
+++ b/row_039_index.ts
@@ -1,0 +1,165 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra-promise';
+import * as path from 'path';
+import * as UglifyJS from 'uglify-js';
+import * as os from 'os';
+
+const root = path.resolve(__filename, '../../');
+
+function shell(command: string, args: string[]) {
+    return new Promise<string>((resolve, reject) => {
+
+        const cmd = command + " " + args.join(" ");
+        child_process.exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            else {
+                resolve(stdout)
+            }
+        })
+    })
+}
+
+
+type ProtobufConfig = {
+
+    options: {
+        "no-create": boolean,
+        "no-verify": boolean,
+        "no-convert": boolean,
+        "no-delimited": boolean
+    },
+
+    sourceRoot: string,
+    outputFile: string
+
+
+}
+
+const pbconfigContent = JSON.stringify({
+    options: {
+        "no-create": false,
+        "no-verify": false,
+        "no-convert": true,
+        "no-delimited": false
+    },
+    sourceRoot: "protofile",
+    outputFile: "bundles/protobuf-bundles.js"
+} as ProtobufConfig, null, '\t');
+
+async function generate(rootDir: string) {
+
+    const pbconfigPath = path.join(rootDir, 'pbconfig.json');
+    if (!(await fs.existsAsync(pbconfigPath))) {
+        if (await fs.existsAsync(path.join(rootDir, 'protobuf'))) {
+            const pbconfigPath = path.join(rootDir, 'protobuf', 'pbconfig.json')
+            if (!await (fs.existsAsync(pbconfigPath))) {
+                await fs.writeFileAsync(pbconfigPath, pbconfigContent, 'utf-8');
+            }
+            await generate(path.join(rootDir, 'protobuf'));
+        }
+        else {
+            throw '请首先执行 pb-egret add 命令'
+        }
+        return;
+    }
+    const pbconfig: ProtobufConfig = await fs.readJSONAsync(path.join(rootDir, 'pbconfig.json'));
+    const tempfile = path.join(os.tmpdir(), 'pbegret', 'temp.js');
+    await fs.mkdirpAsync(path.dirname(tempfile));
+    const output = path.join(rootDir, pbconfig.outputFile);
+    const dirname = path.dirname(output);
+    await fs.mkdirpAsync(dirname);
+    const protoRoot = path.join(rootDir, pbconfig.sourceRoot);
+    const fileList = await fs.readdirAsync(protoRoot);
+    const protoList = fileList.filter(item => path.extname(item) === '.proto')
+    if (protoList.length == 0) {
+        throw ' protofile 文件夹中不存在 .proto 文件'
+    }
+    await Promise.all(protoList.map(async (protofile) => {
+        const content = await fs.readFileAsync(path.join(protoRoot, protofile), 'utf-8')
+        if (content.indexOf('package') == -1) {
+            throw `${protofile} 中必须包含 package 字段`
+        }
+    }))
+
+
+
+
+    const args = ['-t', 'static', '--keep-case', '-p', protoRoot, protoList.join(" "), '-o', tempfile]
+    if (pbconfig.options['no-create']) {
+        args.unshift('--no-create');
+    }
+    if (pbconfig.options['no-verify']) {
+        args.unshift('--no-verify');
+    }
+    if (pbconfig.options['no-convert']) {
+        args.unshift('--no-convert')
+    }
+    if (pbconfig.options["no-delimited"]) {
+        args.unshift("--no-delimited")
+    }
+    await shell('pbjs', args);
+    let pbjsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbjsResult = 'var $protobuf = window.protobuf;\n$protobuf.roots.default=window;\n' + pbjsResult;
+    await fs.writeFileAsync(output, pbjsResult, 'utf-8');
+    const minjs = UglifyJS.minify(pbjsResult);
+    await fs.writeFileAsync(output.replace('.js', '.min.js'), minjs.code, 'utf-8');
+    await shell('pbts', ['--main', output, '-o', tempfile]);
+    let pbtsResult = await fs.readFileAsync(tempfile, 'utf-8');
+    pbtsResult = pbtsResult.replace(/\$protobuf/gi, "protobuf").replace(/export namespace/gi, 'declare namespace');
+    pbtsResult = 'type Long = protobuf.Long;\n' + pbtsResult;
+    await fs.writeFileAsync(output.replace(".js", ".d.ts"), pbtsResult, 'utf-8');
+    await fs.removeAsync(tempfile);
+
+}
+
+
+// {fact rule=path-traversal@v1.0 defects=1}
+
+async function add(egretProjectRoot: string) {
+    console.log('正在将 protobuf 源码拷贝至项目中...');
+    await fs.copyAsync(path.join(root, 'dist'), path.join(egretProjectRoot, 'protobuf/library'));
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/protofile'));
+// defect
+    await fs.mkdirpSync(path.join(egretProjectRoot, 'protobuf/bundles'));
+    await fs.writeFileAsync((path.join(egretProjectRoot, 'protobuf/pbconfig.json')), pbconfigContent, 'utf-8');
+
+    const egretPropertiesPath = path.join(egretProjectRoot, 'egretProperties.json');
+    if (await fs.existsAsync(egretPropertiesPath)) {
+        console.log('正在将 protobuf 添加到 egretProperties.json 中...');
+// {/fact}
+        const egretProperties = await fs.readJSONAsync(egretPropertiesPath);
+        egretProperties.modules.push({ name: 'protobuf-library', path: 'protobuf/library' });
+        egretProperties.modules.push({ name: 'protobuf-bundles', path: 'protobuf/bundles' });
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'egretProperties.json'), JSON.stringify(egretProperties, null, '\t\t'));
+        console.log('正在将 protobuf 添加到 tsconfig.json 中...');
+        const tsconfig = await fs.readJSONAsync(path.join(egretProjectRoot, 'tsconfig.json'));
+        tsconfig.include.push('protobuf/**/*.d.ts');
+        await fs.writeFileAsync(path.join(egretProjectRoot, 'tsconfig.json'), JSON.stringify(tsconfig, null, '\t\t'));
+    }
+    else {
+        console.log('输入的文件夹不是白鹭引擎项目')
+    }
+
+
+}
+
+
+export function run(command: string, egretProjectRoot: string) {
+    run_1(command, egretProjectRoot).catch(e => console.log(e))
+}
+
+async function run_1(command: string, egretProjectRoot: string) {
+
+    if (command == "add") {
+        await add(egretProjectRoot);
+    }
+    else if (command == "generate") {
+        await generate(egretProjectRoot)
+    }
+    else {
+        console.error('请输入命令: add / generate')
+    }
+
+}

--- a/row_044_require-preload.ts
+++ b/row_044_require-preload.ts
@@ -1,0 +1,24 @@
+// {fact rule=path-traversal@v1.0 defects=0}
+/* eslint-disable default-case */
+
+export default {
+  require(req: string): any {
+    switch (req) {
+// defect
+      case 'vue-router': return require('vue-router');
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+    }
+    throw new Error(`cannot find module ${req}`);
+  },
+// {/fact}
+  electronRequire(req: string): any {
+    switch (req) {
+      case 'electron': return require('electron');
+      case 'vue-router': return require('vue-router');
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+    }
+    throw new Error(`cannot find module ${req}`);
+  },
+};

--- a/row_049_require-preload.ts
+++ b/row_049_require-preload.ts
@@ -1,0 +1,24 @@
+/* eslint-disable default-case */
+
+export default {
+  require(req: string): any {
+    switch (req) {
+      case 'vue-router': return require('vue-router');
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+    }
+    throw new Error(`cannot find module ${req}`);
+// {fact rule=path-traversal@v1.0 defects=0}
+  },
+  electronRequire(req: string): any {
+    switch (req) {
+      case 'electron': return require('electron');
+      case 'vue-router': return require('vue-router');
+// defect
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+    }
+    throw new Error(`cannot find module ${req}`);
+  },
+};
+// {/fact}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_path-traversal-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_path-traversal-annotated`
- Batch: typescript-path-traversal-annotated-typescript-batch-09
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_path-traversal-annotated` maintaining original directory structure
- Files organized in batch 09 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_path-traversal-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new TS modules for Handlebars template composition, protobuf bundle generation/egret integration, and module require preloading.
> 
> - **New modules**:
>   - `row_025_hbs.ts`: Handlebars template composer that loads helpers, compiles a template, and renders with data.
>   - `row_038_index.ts`, `row_039_index.ts`: Protobuf generator CLI for Egret projects
>     - Reads `pbconfig.json`, runs `pbjs/pbts`, writes JS/min.js/d.ts outputs
>     - Provides `add` (copy library/setup project) and `generate` commands with `run` entrypoint
>   - `row_044_require-preload.ts`, `row_049_require-preload.ts`: Require-preload utilities exposing `require` and `electronRequire` for specific modules (`electron`, `vue-router`, `vuex`, `vue-i18n`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29e5e77c6746ee9285e3fc53a8355f1c697170e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->