### PR TITLE
Add Typescript Files from typescript_path-traversal-annotated - Batch 10

### DIFF
--- a/row_008_command.ts
+++ b/row_008_command.ts
@@ -1,0 +1,40 @@
+import * as child from "child_process"
+import * as ui from "./ui";
+/**
+ * child_process.exec Promise
+ * @param  {string} command command with argments string
+// {fact rule=path-traversal@v1.0 defects=0}
+ * @param  {ProcessChildOption={}} opt
+ */
+export function getCmdPromise(command:string, opt:ProcessChildOption = {}) {
+	console.log(`cmd: ${command}`)
+	return new Promise<string>((resolve, reject) => {
+// defect
+		child.exec(
+			command,
+			opt,
+			(e,sOut,sErr)=>{
+				if(sOut)resolve(sOut);
+				if(e){
+// {/fact}
+					ui.error(e.message);
+					reject(sErr)
+				}
+			}
+		)
+	})
+}
+
+/**
+ * child_process.exec option
+ */
+export interface ProcessChildOption{
+	cwd?:string,
+	stdio?:any,
+	customFds?:any,
+	env?:any,
+	encoding?:string,
+	timeout?:number,
+	maxBuffer?:number,
+	killSignal?:string
+}

--- a/row_010_user.ts
+++ b/row_010_user.ts
@@ -1,0 +1,80 @@
+import {RequestHandler} from "express";
+import {Assert} from '../lib/pea-script';
+import {
+    Get ,Post ,Errcode ,UserInfo ,UserRaw ,
+} from "@foxzilla/fireblog";
+import {defaultAvatar ,path2url} from "../lib/runtime";
+import * as User from '../model/user';
+import {getBestMatchAvatar} from "../lib/lib";
+import {checkToken, tokenManager} from '../lib/runtime';
+const Router = require('express').Router;
+
+
+const router = Router();
+
+
+router.get(`/info/:user_id(\\d+)`,async function(req,res,next){
+    res.json(await Assert<Get.user.info.$user_id.asyncCall>(async function(user_id){
+        var info :UserInfo &{mail?:UserRaw['mail']} =await User.getInfoById(user_id);
+        if(!await User.isExist(user_id))return{
+            errcode :Errcode.UserNotFound,
+            errmsg  :`Could not find this user.`,
+        };
+        if(tokenManager().checkToken(req.cookies.token) ===Errcode.Ok){
+            info.mail =(await User.getRawById(user_id)).mail;
+        };
+        return {
+            errcode :Errcode.Ok,
+            errmsg  :'ok',
+            ...info,
+        };
+    })(req.params.user_id));
+} as RequestHandler);
+router.post(`/update_info`,checkToken,async function(req,res,next){
+    var cookie:Get.oauth.callback.$oauth_id.CookieValue=req.cookies;
+    res.json(await Assert<Post.user.update_info.asyncCall>(async function(){
+        var updateResult =await User.updateInfo(
+            Number(tokenManager().getTokenInfo(cookie.token).userId),
+            req.body,
+        );
+        if(typeof updateResult==='number'){
+            return {
+                errcode:updateResult,
+                errmsg :'field illegal.'
+            };
+        };
+        return {
+            errcode:Errcode.Ok,
+            errmsg :'ok',
+            ...updateResult,
+        };
+    })());
+} as RequestHandler);
+router.get(`/avatar/:user_id(\\d+)`,async function(req,res,next){
+    var size =function(query:Get.user.avatar.$user_id.query):number{
+        return Number(query.size) ||40;
+// {fact rule=path-traversal@v1.0 defects=1}
+    }(req.query);
+    var userId =req.params['user_id'];
+
+    if(!await User.isExist(userId)){
+        res.status(404);
+// defect
+        res.sendFile(await defaultAvatar(size));
+        return;
+    };
+
+    var options =(await User.getRawById(userId)).avatar;
+    if(!options || Object.keys(options).length===0){
+// {/fact}
+        res.status(404);
+        res.sendFile(await defaultAvatar(size));
+        return;
+    };
+
+    res.redirect(path2url(options[getBestMatchAvatar(options,size)!]));
+} as RequestHandler);
+
+
+
+module.exports =router;

--- a/row_011_user.ts
+++ b/row_011_user.ts
@@ -1,0 +1,80 @@
+import {RequestHandler} from "express";
+import {Assert} from '../lib/pea-script';
+import {
+    Get ,Post ,Errcode ,UserInfo ,UserRaw ,
+} from "@foxzilla/fireblog";
+import {defaultAvatar ,path2url} from "../lib/runtime";
+import * as User from '../model/user';
+import {getBestMatchAvatar} from "../lib/lib";
+import {checkToken, tokenManager} from '../lib/runtime';
+const Router = require('express').Router;
+
+
+const router = Router();
+
+
+router.get(`/info/:user_id(\\d+)`,async function(req,res,next){
+    res.json(await Assert<Get.user.info.$user_id.asyncCall>(async function(user_id){
+        var info :UserInfo &{mail?:UserRaw['mail']} =await User.getInfoById(user_id);
+        if(!await User.isExist(user_id))return{
+            errcode :Errcode.UserNotFound,
+            errmsg  :`Could not find this user.`,
+        };
+        if(tokenManager().checkToken(req.cookies.token) ===Errcode.Ok){
+            info.mail =(await User.getRawById(user_id)).mail;
+        };
+        return {
+            errcode :Errcode.Ok,
+            errmsg  :'ok',
+            ...info,
+        };
+    })(req.params.user_id));
+} as RequestHandler);
+router.post(`/update_info`,checkToken,async function(req,res,next){
+    var cookie:Get.oauth.callback.$oauth_id.CookieValue=req.cookies;
+    res.json(await Assert<Post.user.update_info.asyncCall>(async function(){
+        var updateResult =await User.updateInfo(
+            Number(tokenManager().getTokenInfo(cookie.token).userId),
+            req.body,
+        );
+        if(typeof updateResult==='number'){
+            return {
+                errcode:updateResult,
+                errmsg :'field illegal.'
+            };
+        };
+        return {
+            errcode:Errcode.Ok,
+            errmsg :'ok',
+            ...updateResult,
+        };
+    })());
+} as RequestHandler);
+router.get(`/avatar/:user_id(\\d+)`,async function(req,res,next){
+    var size =function(query:Get.user.avatar.$user_id.query):number{
+        return Number(query.size) ||40;
+    }(req.query);
+    var userId =req.params['user_id'];
+
+    if(!await User.isExist(userId)){
+        res.status(404);
+        res.sendFile(await defaultAvatar(size));
+        return;
+// {fact rule=path-traversal@v1.0 defects=1}
+    };
+
+    var options =(await User.getRawById(userId)).avatar;
+    if(!options || Object.keys(options).length===0){
+        res.status(404);
+// defect
+        res.sendFile(await defaultAvatar(size));
+        return;
+    };
+
+    res.redirect(path2url(options[getBestMatchAvatar(options,size)!]));
+} as RequestHandler);
+// {/fact}
+
+
+
+module.exports =router;

--- a/row_026_preview.ts
+++ b/row_026_preview.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import * as uri from 'vscode-uri';
+import * as child_process from 'child_process';
+import * as util from './util';
+import * as shiki from 'shiki';
+import { ensureKusion } from './installer';
+import * as output from './output';
+import * as fs from 'fs';
+
+const viewType = 'kusion.dataPreview';
+
+export function showDataPreview(dataPreviewSettings: ShowDataPreviewSettings) {
+    if (!ensureKusion(true, false)) {
+        return;
+    }
+    var resource: vscode.Uri | undefined = util.activeTextEditorDocument()?.uri;
+    if (resource === undefined || !util.inKusionStackCheck(resource)) {
+        return;
+    }
+
+    var locked = !!dataPreviewSettings.locked;
+    const resourceColumn = (vscode.window.activeTextEditor && vscode.window.activeTextEditor.viewColumn) || vscode.ViewColumn.One;
+    var previewColumn = dataPreviewSettings.sideBySide ? vscode.ViewColumn.Beside : resourceColumn;
+    const root = util.kclWorkspaceRoot(resource);
+    const stackUri = uri.Utils.dirname(resource);
+    const stackFullName = util.getProjectStackFullName(stackUri, root);
+    vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: "Generating stack configuration in YAML...",
+        cancellable: false
+        }, (progress) => {
+        return new Promise<void>((resolve, reject) => {
+            compileStackData(stackUri).then(async (data) => {
+                resolve();
+                const webview = vscode.window.createWebviewPanel(
+                    viewType,
+                    getViewTitle(stackFullName, locked),
+                    previewColumn,
+                    { enableFindWidget: true, enableScripts: true }
+                );
+                var extensionContext = vscode.extensions.getExtension("KusionStack.kusion");
+                if (extensionContext?.extensionUri) {
+                    var iconPath = {
+                        dark: vscode.Uri.joinPath(extensionContext.extensionUri, 'images', 'preview-dark.svg'),
+                        light: vscode.Uri.joinPath(extensionContext.extensionUri, 'images', 'preview-light.svg'),
+                    };
+                    webview.iconPath = iconPath;
+                }
+                const darkHighlighter = await shiki.getHighlighter({
+                    theme: 'min-dark'
+                });
+                const lightHighlighter = await shiki.getHighlighter({
+                    theme: 'min-light'
+                });
+                const darkHtml = renderInShikiTheme(data, darkHighlighter);
+                const lightHtml = renderInShikiTheme(data, lightHighlighter);
+        
+                webview.webview.html = vscode.window.activeColorTheme.kind in [1, 4] ? lightHtml : darkHtml;
+        
+                vscode.window.onDidChangeActiveColorTheme((theme) => {
+                    webview.webview.html = theme.kind in [1, 4] ? lightHtml : darkHtml;
+                });
+            },
+            (reason) => {
+                reject(reason);
+            });
+        });
+    });
+
+    function renderInShikiTheme(data: string, highlighter: shiki.Highlighter) {
+        const codeBlock = highlighter.codeToHtml(`${data}`, { lang: 'yaml' });
+        return `<!DOCTYPE html><html lang="en"><body>${codeBlock}</body></html>`;
+    }
+}
+
+function getViewTitle(stackLabel: string, locked: boolean,): string {
+    return locked
+        ? `[Preview] ${stackLabel}`
+        : `Preview ${stackLabel}`;
+}
+
+interface ShowDataPreviewSettings {
+    readonly sideBySide?: boolean;
+    readonly locked?: boolean;
+// {fact rule=path-traversal@v1.0 defects=1}
+}
+
+async function compileStackData(stackUri: vscode.Uri): Promise<string> {
+    const command = `kusion compile`;
+    return new Promise((resolve, reject) => {
+// defect
+        child_process.exec(command, { cwd: stackUri.path }, (err, stdout, stderr) => {
+            if (err || stderr) {
+                output.show();
+                output.appendLine(`Stack Compile Failed:`, false);
+                // todo: this is because that kusion cli output the err message to the stdout
+                // filter the stdout message, remove the spinner message
+// {/fact}
+                const cleanStdout = stdout.split('\n').filter(line => !line.includes('Generating Spec in the Stack')).join('\n');
+                output.appendLine(cleanStdout.trimStart(), true);
+                reject();
+            }
+            fs.readFile(util.goldenPath(stackUri.fsPath), 'utf-8', (err, fileContent) => {
+                if (err) {
+                    output.show();
+                    output.appendLine(`Stack Compile Failed:`, false);
+                    output.appendLine(err.message, false);
+                    reject();
+                  }
+                  resolve(fileContent);
+            });
+        });
+    });
+}

--- a/row_047_require-preload.ts
+++ b/row_047_require-preload.ts
@@ -1,0 +1,24 @@
+/* eslint-disable default-case */
+
+export default {
+  require(req: string): any {
+    switch (req) {
+      case 'vue-router': return require('vue-router');
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+// {fact rule=path-traversal@v1.0 defects=0}
+    }
+    throw new Error(`cannot find module ${req}`);
+  },
+  electronRequire(req: string): any {
+    switch (req) {
+// defect
+      case 'electron': return require('electron');
+      case 'vue-router': return require('vue-router');
+      case 'vuex': return require('vuex');
+      case 'vue-i18n': return require('vue-i18n');
+    }
+    throw new Error(`cannot find module ${req}`);
+// {/fact}
+  },
+};


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Typescript files from the `typescript_path-traversal-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `typescript_path-traversal-annotated`
- Batch: typescript-path-traversal-annotated-typescript-batch-10
- Language: Typescript
- Contains typescript files collected from the source directory

## 🔍 Changes
- Added typescript files from `typescript_path-traversal-annotated` maintaining original directory structure
- Files organized in batch 10 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `typescript_path-traversal-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new TS modules: a child_process exec promise utility, Express user info/update/avatar routes, a VS Code YAML data preview panel, and a require/electronRequire preload helper.
> 
> - **Backend (Express)**:
>   - Adds `row_010_user.ts` and `row_011_user.ts` defining `GET /info/:user_id`, `POST /update_info`, and `GET /avatar/:user_id` routes using `User` model and token checks.
> - **Editor (VS Code Extension)**:
>   - Introduces `row_026_preview.ts` to compile stack data (`kusion compile`) and render YAML with Shiki in a webview, reacting to theme changes.
> - **Core Utility**:
>   - Adds `row_008_command.ts` providing `getCmdPromise(command, opt)` wrapper around `child_process.exec` with `ProcessChildOption` interface.
> - **Preload Helper**:
>   - Adds `row_047_require-preload.ts` exposing `require` and `electronRequire` switch-based module loaders for select packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c50ec9fd12d7b658bbe4ae7939c452121dbf9179. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->